### PR TITLE
Quick fixes

### DIFF
--- a/contracts/SettV4h.sol
+++ b/contracts/SettV4h.sol
@@ -68,9 +68,7 @@ contract SettV4h is ERC20Upgradeable, SettAccessControlDefended, PausableUpgrade
 
     modifier whenNotPaused() override {
         require(!paused(), "Pausable: paused");
-        if(address(GAC) != address(0)){
-            require(!GAC.paused(), "Pausable: GAC Paused");
-        }
+        require(!GAC.paused(), "Pausable: GAC Paused");
         _;
     }
 
@@ -82,8 +80,7 @@ contract SettV4h is ERC20Upgradeable, SettAccessControlDefended, PausableUpgrade
         address _guardian,
         bool _overrideTokenName,
         string memory _namePrefix,
-        string memory _symbolPrefix,
-        address _gac
+        string memory _symbolPrefix
     ) public initializer whenNotPaused {
         IERC20Detailed namedToken = IERC20Detailed(_token);
         string memory tokenName = namedToken.name();


### PR DESCRIPTION
- removed unused _gac parameter from constructor
- refactor whenNotPaused()

Tests passing:

![Screenshot 2021-12-09 at 12 09 23 AM](https://user-images.githubusercontent.com/31198893/145265082-6a199f07-ea65-49b0-b296-673c8ec128cf.png)

