### PR TITLE
Add blacklist check for accounts + fixes

### DIFF
--- a/contracts/SettV1_1h.sol
+++ b/contracts/SettV1_1h.sol
@@ -391,6 +391,7 @@ contract SettV1_1h is ERC20Upgradeable, PausableUpgradeable, SettAccessControlDe
     ) public virtual whenNotPaused override returns (bool) {
         _blockLocked();
         _blacklisted(msg.sender);
+        _blacklisted(sender);
         require(!GAC.transferFromDisabled(), "transferFrom: GAC transferFromDisabled");
         return super.transferFrom(sender, recipient, amount);
     }

--- a/contracts/SettV1_1h.sol
+++ b/contracts/SettV1_1h.sol
@@ -194,6 +194,10 @@ contract SettV1_1h is ERC20Upgradeable, PausableUpgradeable, SettAccessControlDe
         require(blockLock[msg.sender] < block.number, "blockLocked");
     }
 
+    function _blacklisted(address _recipient) internal view {
+        require(!GAC.isBlacklisted(_recipient), "blacklisted");
+    }
+
     /// ===== View Functions =====
 
     function version() public view returns (string memory) {
@@ -227,6 +231,7 @@ contract SettV1_1h is ERC20Upgradeable, PausableUpgradeable, SettAccessControlDe
     function deposit(uint256 _amount) public whenNotPaused {
         _defend();
         _blockLocked();
+        _blacklisted(msg.sender);
 
         _lockForBlock(msg.sender);
         _deposit(_amount);
@@ -237,6 +242,7 @@ contract SettV1_1h is ERC20Upgradeable, PausableUpgradeable, SettAccessControlDe
     function depositAll() external whenNotPaused {
         _defend();
         _blockLocked();
+        _blacklisted(msg.sender);
 
         _lockForBlock(msg.sender);
         _deposit(token.balanceOf(msg.sender));
@@ -246,6 +252,7 @@ contract SettV1_1h is ERC20Upgradeable, PausableUpgradeable, SettAccessControlDe
     function withdraw(uint256 _shares) public whenNotPaused {
         _defend();
         _blockLocked();
+        _blacklisted(msg.sender);
 
         _lockForBlock(msg.sender);
         _withdraw(_shares);
@@ -255,6 +262,7 @@ contract SettV1_1h is ERC20Upgradeable, PausableUpgradeable, SettAccessControlDe
     function withdrawAll() external whenNotPaused {
         _defend();
         _blockLocked();
+        _blacklisted(msg.sender);
 
         _lockForBlock(msg.sender);
         _withdraw(balanceOf(msg.sender));
@@ -372,6 +380,7 @@ contract SettV1_1h is ERC20Upgradeable, PausableUpgradeable, SettAccessControlDe
     /// @dev Add blockLock to transfers, users cannot transfer tokens in the same block as a deposit or withdrawal.
     function transfer(address recipient, uint256 amount) public virtual whenNotPaused override returns (bool) {
         _blockLocked();
+        _blacklisted(msg.sender);
         return super.transfer(recipient, amount);
     }
 
@@ -381,6 +390,7 @@ contract SettV1_1h is ERC20Upgradeable, PausableUpgradeable, SettAccessControlDe
         uint256 amount
     ) public virtual whenNotPaused override returns (bool) {
         _blockLocked();
+        _blacklisted(msg.sender);
         require(!GAC.transferFromDisabled(), "transferFrom: GAC transferFromDisabled");
         return super.transferFrom(sender, recipient, amount);
     }

--- a/contracts/SettV1_1h.sol
+++ b/contracts/SettV1_1h.sol
@@ -264,21 +264,21 @@ contract SettV1_1h is ERC20Upgradeable, PausableUpgradeable, SettAccessControlDe
 
     /// @notice Set minimum threshold of underlying that must be deposited in strategy
     /// @notice Can only be changed by governance
-    function setMin(uint256 _min) external {
+    function setMin(uint256 _min) external whenNotPaused {
         _onlyGovernance();
         min = _min;
     }
 
     /// @notice Change controller address
     /// @notice Can only be changed by governance
-    function setController(address _controller) public {
+    function setController(address _controller) public whenNotPaused {
         _onlyGovernance();
         controller = _controller;
     }
 
     /// @notice Change guardian address
     /// @notice Can only be changed by governance
-    function setGuardian(address _guardian) external {
+    function setGuardian(address _guardian) external whenNotPaused {
         _onlyGovernance();
         guardian = _guardian;
     }

--- a/contracts/SettV1h.sol
+++ b/contracts/SettV1h.sol
@@ -1241,6 +1241,10 @@ contract SettV1h is ERC20Upgradeable, SettAccessControlDefendedV1 {
         require(blockLock[msg.sender] < block.number, "blockLocked");
     }
 
+    function _blacklisted(address _recipient) internal view {
+        require(!GAC.isBlacklisted(_recipient), "blacklisted");
+    }
+
     /// ===== View Functions =====
 
     function getPricePerFullShare() public view returns (uint256) {
@@ -1270,6 +1274,7 @@ contract SettV1h is ERC20Upgradeable, SettAccessControlDefendedV1 {
     function deposit(uint256 _amount) public whenNotPaused {
         _defend();
         _blockLocked();
+        _blacklisted(msg.sender);
 
         _lockForBlock(msg.sender);
         _deposit(_amount);
@@ -1280,6 +1285,7 @@ contract SettV1h is ERC20Upgradeable, SettAccessControlDefendedV1 {
     function depositFor(address recipient, uint256 _amount) public whenNotPaused {
         _defend();
         _blockLocked();
+        _blacklisted(msg.sender);
 
         // Lock for recipient so receiver cannot perform any other actions within the block.
         _lockForBlock(recipient);
@@ -1291,6 +1297,7 @@ contract SettV1h is ERC20Upgradeable, SettAccessControlDefendedV1 {
     function depositAll() external whenNotPaused {
         _defend();
         _blockLocked();
+        _blacklisted(msg.sender);
 
         _lockForBlock(msg.sender);
         _deposit(token.balanceOf(msg.sender));
@@ -1300,6 +1307,7 @@ contract SettV1h is ERC20Upgradeable, SettAccessControlDefendedV1 {
     function withdraw(uint256 _shares) public whenNotPaused {
         _defend();
         _blockLocked();
+        _blacklisted(msg.sender);
 
         _lockForBlock(msg.sender);
         _withdraw(_shares);
@@ -1309,6 +1317,7 @@ contract SettV1h is ERC20Upgradeable, SettAccessControlDefendedV1 {
     function withdrawAll() external whenNotPaused {
         _defend();
         _blockLocked();
+        _blacklisted(msg.sender);
 
         _lockForBlock(msg.sender);
         _withdraw(balanceOf(msg.sender));
@@ -1413,6 +1422,7 @@ contract SettV1h is ERC20Upgradeable, SettAccessControlDefendedV1 {
     /// @dev Add blockLock to transfers, users cannot transfer tokens in the same block as a deposit or withdrawal.
     function transfer(address recipient, uint256 amount) public virtual override whenNotPaused returns (bool) {
         _blockLocked();
+        _blacklisted(msg.sender);
         return super.transfer(recipient, amount);
     }
 
@@ -1429,6 +1439,7 @@ contract SettV1h is ERC20Upgradeable, SettAccessControlDefendedV1 {
         uint256 amount
     ) public virtual override whenNotPaused returns (bool) {
         _blockLocked();
+        _blacklisted(msg.sender);
         require(!GAC.transferFromDisabled(), "transferFrom: GAC transferFromDisabled");
         return super.transferFrom(sender, recipient, amount);
     }

--- a/contracts/SettV1h.sol
+++ b/contracts/SettV1h.sol
@@ -1440,6 +1440,7 @@ contract SettV1h is ERC20Upgradeable, SettAccessControlDefendedV1 {
     ) public virtual override whenNotPaused returns (bool) {
         _blockLocked();
         _blacklisted(msg.sender);
+        _blacklisted(sender);
         require(!GAC.transferFromDisabled(), "transferFrom: GAC transferFromDisabled");
         return super.transferFrom(sender, recipient, amount);
     }

--- a/contracts/SettV4h.sol
+++ b/contracts/SettV4h.sol
@@ -128,6 +128,10 @@ contract SettV4h is ERC20Upgradeable, SettAccessControlDefended, PausableUpgrade
         require(blockLock[msg.sender] < block.number, "blockLocked");
     }
 
+    function _blacklisted(address _recipient) internal view {
+        require(!GAC.isBlacklisted(_recipient), "blacklisted");
+    }
+
     /// ===== View Functions =====
 
     function version() public view returns (string memory) {
@@ -161,6 +165,7 @@ contract SettV4h is ERC20Upgradeable, SettAccessControlDefended, PausableUpgrade
     function deposit(uint256 _amount) public whenNotPaused {
         _defend();
         _blockLocked();
+        _blacklisted(msg.sender);
 
         _lockForBlock(msg.sender);
         _depositWithAuthorization(_amount, new bytes32[](0));
@@ -170,6 +175,7 @@ contract SettV4h is ERC20Upgradeable, SettAccessControlDefended, PausableUpgrade
     function deposit(uint256 _amount, bytes32[] memory proof) public whenNotPaused {
         _defend();
         _blockLocked();
+        _blacklisted(msg.sender);
 
         _lockForBlock(msg.sender);
         _depositWithAuthorization(_amount, proof);
@@ -180,6 +186,7 @@ contract SettV4h is ERC20Upgradeable, SettAccessControlDefended, PausableUpgrade
     function depositAll() external whenNotPaused {
         _defend();
         _blockLocked();
+        _blacklisted(msg.sender);
 
         _lockForBlock(msg.sender);
         _depositWithAuthorization(token.balanceOf(msg.sender), new bytes32[](0));
@@ -189,6 +196,7 @@ contract SettV4h is ERC20Upgradeable, SettAccessControlDefended, PausableUpgrade
     function depositAll(bytes32[] memory proof) external whenNotPaused {
         _defend();
         _blockLocked();
+        _blacklisted(msg.sender);
 
         _lockForBlock(msg.sender);
         _depositWithAuthorization(token.balanceOf(msg.sender), proof);
@@ -199,6 +207,7 @@ contract SettV4h is ERC20Upgradeable, SettAccessControlDefended, PausableUpgrade
     function depositFor(address _recipient, uint256 _amount) public whenNotPaused {
         _defend();
         _blockLocked();
+        _blacklisted(_recipient);
 
         _lockForBlock(_recipient);
         _depositForWithAuthorization(_recipient, _amount, new bytes32[](0));
@@ -212,6 +221,7 @@ contract SettV4h is ERC20Upgradeable, SettAccessControlDefended, PausableUpgrade
     ) public whenNotPaused {
         _defend();
         _blockLocked();
+        _blacklisted(_recipient);
 
         _lockForBlock(_recipient);
         _depositForWithAuthorization(_recipient, _amount, proof);
@@ -221,6 +231,7 @@ contract SettV4h is ERC20Upgradeable, SettAccessControlDefended, PausableUpgrade
     function withdraw(uint256 _shares) public whenNotPaused {
         _defend();
         _blockLocked();
+        _blacklisted(msg.sender);
 
         _lockForBlock(msg.sender);
         _withdraw(_shares);
@@ -230,6 +241,7 @@ contract SettV4h is ERC20Upgradeable, SettAccessControlDefended, PausableUpgrade
     function withdrawAll() external whenNotPaused {
         _defend();
         _blockLocked();
+        _blacklisted(msg.sender);
 
         _lockForBlock(msg.sender);
         _withdraw(balanceOf(msg.sender));
@@ -374,6 +386,7 @@ contract SettV4h is ERC20Upgradeable, SettAccessControlDefended, PausableUpgrade
     /// @dev Add blockLock to transfers, users cannot transfer tokens in the same block as a deposit or withdrawal.
     function transfer(address recipient, uint256 amount) public virtual override whenNotPaused returns (bool) {
         _blockLocked();
+        _blacklisted(msg.sender);
         return super.transfer(recipient, amount);
     }
 
@@ -383,6 +396,7 @@ contract SettV4h is ERC20Upgradeable, SettAccessControlDefended, PausableUpgrade
         uint256 amount
     ) public virtual override whenNotPaused returns (bool) {
         _blockLocked();
+        _blacklisted(msg.sender);
         require(!GAC.transferFromDisabled(), "transferFrom: GAC transferFromDisabled");
         return super.transferFrom(sender, recipient, amount);
     }

--- a/contracts/SettV4h.sol
+++ b/contracts/SettV4h.sol
@@ -207,7 +207,7 @@ contract SettV4h is ERC20Upgradeable, SettAccessControlDefended, PausableUpgrade
     function depositFor(address _recipient, uint256 _amount) public whenNotPaused {
         _defend();
         _blockLocked();
-        _blacklisted(_recipient);
+        _blacklisted(msg.sender);
 
         _lockForBlock(_recipient);
         _depositForWithAuthorization(_recipient, _amount, new bytes32[](0));
@@ -221,7 +221,7 @@ contract SettV4h is ERC20Upgradeable, SettAccessControlDefended, PausableUpgrade
     ) public whenNotPaused {
         _defend();
         _blockLocked();
-        _blacklisted(_recipient);
+        _blacklisted(msg.sender);
 
         _lockForBlock(_recipient);
         _depositForWithAuthorization(_recipient, _amount, proof);
@@ -397,6 +397,7 @@ contract SettV4h is ERC20Upgradeable, SettAccessControlDefended, PausableUpgrade
     ) public virtual override whenNotPaused returns (bool) {
         _blockLocked();
         _blacklisted(msg.sender);
+        _blacklisted(sender);
         require(!GAC.transferFromDisabled(), "transferFrom: GAC transferFromDisabled");
         return super.transferFrom(sender, recipient, amount);
     }

--- a/contracts/_original/SettV1.sol
+++ b/contracts/_original/SettV1.sol
@@ -1,0 +1,1423 @@
+/**
+ *Submitted for verification at Etherscan.io on 2021-04-18
+*/
+
+// Sources flattened with hardhat v2.0.3 https://hardhat.org
+
+// File deps/@openzeppelin/contracts-upgradeable/token/ERC20/IERC20Upgradeable.sol
+
+// SPDX-License-Identifier: MIT
+
+pragma solidity ^0.6.0;
+
+/**
+ * @dev Interface of the ERC20 standard as defined in the EIP.
+ */
+interface IERC20Upgradeable {
+    /**
+     * @dev Returns the amount of tokens in existence.
+     */
+    function totalSupply() external view returns (uint256);
+
+    /**
+     * @dev Returns the amount of tokens owned by `account`.
+     */
+    function balanceOf(address account) external view returns (uint256);
+
+    /**
+     * @dev Moves `amount` tokens from the caller's account to `recipient`.
+     *
+     * Returns a boolean value indicating whether the operation succeeded.
+     *
+     * Emits a {Transfer} event.
+     */
+    function transfer(address recipient, uint256 amount) external returns (bool);
+
+    /**
+     * @dev Returns the remaining number of tokens that `spender` will be
+     * allowed to spend on behalf of `owner` through {transferFrom}. This is
+     * zero by default.
+     *
+     * This value changes when {approve} or {transferFrom} are called.
+     */
+    function allowance(address owner, address spender) external view returns (uint256);
+
+    /**
+     * @dev Sets `amount` as the allowance of `spender` over the caller's tokens.
+     *
+     * Returns a boolean value indicating whether the operation succeeded.
+     *
+     * IMPORTANT: Beware that changing an allowance with this method brings the risk
+     * that someone may use both the old and the new allowance by unfortunate
+     * transaction ordering. One possible solution to mitigate this race
+     * condition is to first reduce the spender's allowance to 0 and set the
+     * desired value afterwards:
+     * https://github.com/ethereum/EIPs/issues/20#issuecomment-263524729
+     *
+     * Emits an {Approval} event.
+     */
+    function approve(address spender, uint256 amount) external returns (bool);
+
+    /**
+     * @dev Moves `amount` tokens from `sender` to `recipient` using the
+     * allowance mechanism. `amount` is then deducted from the caller's
+     * allowance.
+     *
+     * Returns a boolean value indicating whether the operation succeeded.
+     *
+     * Emits a {Transfer} event.
+     */
+    function transferFrom(address sender, address recipient, uint256 amount) external returns (bool);
+
+    /**
+     * @dev Emitted when `value` tokens are moved from one account (`from`) to
+     * another (`to`).
+     *
+     * Note that `value` may be zero.
+     */
+    event Transfer(address indexed from, address indexed to, uint256 value);
+
+    /**
+     * @dev Emitted when the allowance of a `spender` for an `owner` is set by
+     * a call to {approve}. `value` is the new allowance.
+     */
+    event Approval(address indexed owner, address indexed spender, uint256 value);
+}
+
+
+// File deps/@openzeppelin/contracts-upgradeable/math/SafeMathUpgradeable.sol
+
+
+
+pragma solidity ^0.6.0;
+
+/**
+ * @dev Wrappers over Solidity's arithmetic operations with added overflow
+ * checks.
+ *
+ * Arithmetic operations in Solidity wrap on overflow. This can easily result
+ * in bugs, because programmers usually assume that an overflow raises an
+ * error, which is the standard behavior in high level programming languages.
+ * `SafeMath` restores this intuition by reverting the transaction when an
+ * operation overflows.
+ *
+ * Using this library instead of the unchecked operations eliminates an entire
+ * class of bugs, so it's recommended to use it always.
+ */
+library SafeMathUpgradeable {
+    /**
+     * @dev Returns the addition of two unsigned integers, reverting on
+     * overflow.
+     *
+     * Counterpart to Solidity's `+` operator.
+     *
+     * Requirements:
+     *
+     * - Addition cannot overflow.
+     */
+    function add(uint256 a, uint256 b) internal pure returns (uint256) {
+        uint256 c = a + b;
+        require(c >= a, "SafeMath: addition overflow");
+
+        return c;
+    }
+
+    /**
+     * @dev Returns the subtraction of two unsigned integers, reverting on
+     * overflow (when the result is negative).
+     *
+     * Counterpart to Solidity's `-` operator.
+     *
+     * Requirements:
+     *
+     * - Subtraction cannot overflow.
+     */
+    function sub(uint256 a, uint256 b) internal pure returns (uint256) {
+        return sub(a, b, "SafeMath: subtraction overflow");
+    }
+
+    /**
+     * @dev Returns the subtraction of two unsigned integers, reverting with custom message on
+     * overflow (when the result is negative).
+     *
+     * Counterpart to Solidity's `-` operator.
+     *
+     * Requirements:
+     *
+     * - Subtraction cannot overflow.
+     */
+    function sub(uint256 a, uint256 b, string memory errorMessage) internal pure returns (uint256) {
+        require(b <= a, errorMessage);
+        uint256 c = a - b;
+
+        return c;
+    }
+
+    /**
+     * @dev Returns the multiplication of two unsigned integers, reverting on
+     * overflow.
+     *
+     * Counterpart to Solidity's `*` operator.
+     *
+     * Requirements:
+     *
+     * - Multiplication cannot overflow.
+     */
+    function mul(uint256 a, uint256 b) internal pure returns (uint256) {
+        // Gas optimization: this is cheaper than requiring 'a' not being zero, but the
+        // benefit is lost if 'b' is also tested.
+        // See: https://github.com/OpenZeppelin/openzeppelin-contracts/pull/522
+        if (a == 0) {
+            return 0;
+        }
+
+        uint256 c = a * b;
+        require(c / a == b, "SafeMath: multiplication overflow");
+
+        return c;
+    }
+
+    /**
+     * @dev Returns the integer division of two unsigned integers. Reverts on
+     * division by zero. The result is rounded towards zero.
+     *
+     * Counterpart to Solidity's `/` operator. Note: this function uses a
+     * `revert` opcode (which leaves remaining gas untouched) while Solidity
+     * uses an invalid opcode to revert (consuming all remaining gas).
+     *
+     * Requirements:
+     *
+     * - The divisor cannot be zero.
+     */
+    function div(uint256 a, uint256 b) internal pure returns (uint256) {
+        return div(a, b, "SafeMath: division by zero");
+    }
+
+    /**
+     * @dev Returns the integer division of two unsigned integers. Reverts with custom message on
+     * division by zero. The result is rounded towards zero.
+     *
+     * Counterpart to Solidity's `/` operator. Note: this function uses a
+     * `revert` opcode (which leaves remaining gas untouched) while Solidity
+     * uses an invalid opcode to revert (consuming all remaining gas).
+     *
+     * Requirements:
+     *
+     * - The divisor cannot be zero.
+     */
+    function div(uint256 a, uint256 b, string memory errorMessage) internal pure returns (uint256) {
+        require(b > 0, errorMessage);
+        uint256 c = a / b;
+        // assert(a == b * c + a % b); // There is no case in which this doesn't hold
+
+        return c;
+    }
+
+    /**
+     * @dev Returns the remainder of dividing two unsigned integers. (unsigned integer modulo),
+     * Reverts when dividing by zero.
+     *
+     * Counterpart to Solidity's `%` operator. This function uses a `revert`
+     * opcode (which leaves remaining gas untouched) while Solidity uses an
+     * invalid opcode to revert (consuming all remaining gas).
+     *
+     * Requirements:
+     *
+     * - The divisor cannot be zero.
+     */
+    function mod(uint256 a, uint256 b) internal pure returns (uint256) {
+        return mod(a, b, "SafeMath: modulo by zero");
+    }
+
+    /**
+     * @dev Returns the remainder of dividing two unsigned integers. (unsigned integer modulo),
+     * Reverts with custom message when dividing by zero.
+     *
+     * Counterpart to Solidity's `%` operator. This function uses a `revert`
+     * opcode (which leaves remaining gas untouched) while Solidity uses an
+     * invalid opcode to revert (consuming all remaining gas).
+     *
+     * Requirements:
+     *
+     * - The divisor cannot be zero.
+     */
+    function mod(uint256 a, uint256 b, string memory errorMessage) internal pure returns (uint256) {
+        require(b != 0, errorMessage);
+        return a % b;
+    }
+}
+
+
+// File deps/@openzeppelin/contracts-upgradeable/utils/AddressUpgradeable.sol
+
+
+
+pragma solidity ^0.6.2;
+
+/**
+ * @dev Collection of functions related to the address type
+ */
+library AddressUpgradeable {
+    /**
+     * @dev Returns true if `account` is a contract.
+     *
+     * [IMPORTANT]
+     * ====
+     * It is unsafe to assume that an address for which this function returns
+     * false is an externally-owned account (EOA) and not a contract.
+     *
+     * Among others, `isContract` will return false for the following
+     * types of addresses:
+     *
+     *  - an externally-owned account
+     *  - a contract in construction
+     *  - an address where a contract will be created
+     *  - an address where a contract lived, but was destroyed
+     * ====
+     */
+    function isContract(address account) internal view returns (bool) {
+        // This method relies in extcodesize, which returns 0 for contracts in
+        // construction, since the code is only stored at the end of the
+        // constructor execution.
+
+        uint256 size;
+        // solhint-disable-next-line no-inline-assembly
+        assembly { size := extcodesize(account) }
+        return size > 0;
+    }
+
+    /**
+     * @dev Replacement for Solidity's `transfer`: sends `amount` wei to
+     * `recipient`, forwarding all available gas and reverting on errors.
+     *
+     * https://eips.ethereum.org/EIPS/eip-1884[EIP1884] increases the gas cost
+     * of certain opcodes, possibly making contracts go over the 2300 gas limit
+     * imposed by `transfer`, making them unable to receive funds via
+     * `transfer`. {sendValue} removes this limitation.
+     *
+     * https://diligence.consensys.net/posts/2019/09/stop-using-soliditys-transfer-now/[Learn more].
+     *
+     * IMPORTANT: because control is transferred to `recipient`, care must be
+     * taken to not create reentrancy vulnerabilities. Consider using
+     * {ReentrancyGuard} or the
+     * https://solidity.readthedocs.io/en/v0.5.11/security-considerations.html#use-the-checks-effects-interactions-pattern[checks-effects-interactions pattern].
+     */
+    function sendValue(address payable recipient, uint256 amount) internal {
+        require(address(this).balance >= amount, "Address: insufficient balance");
+
+        // solhint-disable-next-line avoid-low-level-calls, avoid-call-value
+        (bool success, ) = recipient.call{ value: amount }("");
+        require(success, "Address: unable to send value, recipient may have reverted");
+    }
+
+    /**
+     * @dev Performs a Solidity function call using a low level `call`. A
+     * plain`call` is an unsafe replacement for a function call: use this
+     * function instead.
+     *
+     * If `target` reverts with a revert reason, it is bubbled up by this
+     * function (like regular Solidity function calls).
+     *
+     * Returns the raw returned data. To convert to the expected return value,
+     * use https://solidity.readthedocs.io/en/latest/units-and-global-variables.html?highlight=abi.decode#abi-encoding-and-decoding-functions[`abi.decode`].
+     *
+     * Requirements:
+     *
+     * - `target` must be a contract.
+     * - calling `target` with `data` must not revert.
+     *
+     * _Available since v3.1._
+     */
+    function functionCall(address target, bytes memory data) internal returns (bytes memory) {
+      return functionCall(target, data, "Address: low-level call failed");
+    }
+
+    /**
+     * @dev Same as {xref-Address-functionCall-address-bytes-}[`functionCall`], but with
+     * `errorMessage` as a fallback revert reason when `target` reverts.
+     *
+     * _Available since v3.1._
+     */
+    function functionCall(address target, bytes memory data, string memory errorMessage) internal returns (bytes memory) {
+        return _functionCallWithValue(target, data, 0, errorMessage);
+    }
+
+    /**
+     * @dev Same as {xref-Address-functionCall-address-bytes-}[`functionCall`],
+     * but also transferring `value` wei to `target`.
+     *
+     * Requirements:
+     *
+     * - the calling contract must have an ETH balance of at least `value`.
+     * - the called Solidity function must be `payable`.
+     *
+     * _Available since v3.1._
+     */
+    function functionCallWithValue(address target, bytes memory data, uint256 value) internal returns (bytes memory) {
+        return functionCallWithValue(target, data, value, "Address: low-level call with value failed");
+    }
+
+    /**
+     * @dev Same as {xref-Address-functionCallWithValue-address-bytes-uint256-}[`functionCallWithValue`], but
+     * with `errorMessage` as a fallback revert reason when `target` reverts.
+     *
+     * _Available since v3.1._
+     */
+    function functionCallWithValue(address target, bytes memory data, uint256 value, string memory errorMessage) internal returns (bytes memory) {
+        require(address(this).balance >= value, "Address: insufficient balance for call");
+        return _functionCallWithValue(target, data, value, errorMessage);
+    }
+
+    function _functionCallWithValue(address target, bytes memory data, uint256 weiValue, string memory errorMessage) private returns (bytes memory) {
+        require(isContract(target), "Address: call to non-contract");
+
+        // solhint-disable-next-line avoid-low-level-calls
+        (bool success, bytes memory returndata) = target.call{ value: weiValue }(data);
+        if (success) {
+            return returndata;
+        } else {
+            // Look for revert reason and bubble it up if present
+            if (returndata.length > 0) {
+                // The easiest way to bubble the revert reason is using memory via assembly
+
+                // solhint-disable-next-line no-inline-assembly
+                assembly {
+                    let returndata_size := mload(returndata)
+                    revert(add(32, returndata), returndata_size)
+                }
+            } else {
+                revert(errorMessage);
+            }
+        }
+    }
+}
+
+
+// File deps/@openzeppelin/contracts-upgradeable/token/ERC20/SafeERC20Upgradeable.sol
+
+
+
+pragma solidity ^0.6.0;
+
+
+
+/**
+ * @title SafeERC20
+ * @dev Wrappers around ERC20 operations that throw on failure (when the token
+ * contract returns false). Tokens that return no value (and instead revert or
+ * throw on failure) are also supported, non-reverting calls are assumed to be
+ * successful.
+ * To use this library you can add a `using SafeERC20 for IERC20;` statement to your contract,
+ * which allows you to call the safe operations as `token.safeTransfer(...)`, etc.
+ */
+library SafeERC20Upgradeable {
+    using SafeMathUpgradeable for uint256;
+    using AddressUpgradeable for address;
+
+    function safeTransfer(IERC20Upgradeable token, address to, uint256 value) internal {
+        _callOptionalReturn(token, abi.encodeWithSelector(token.transfer.selector, to, value));
+    }
+
+    function safeTransferFrom(IERC20Upgradeable token, address from, address to, uint256 value) internal {
+        _callOptionalReturn(token, abi.encodeWithSelector(token.transferFrom.selector, from, to, value));
+    }
+
+    /**
+     * @dev Deprecated. This function has issues similar to the ones found in
+     * {IERC20-approve}, and its usage is discouraged.
+     *
+     * Whenever possible, use {safeIncreaseAllowance} and
+     * {safeDecreaseAllowance} instead.
+     */
+    function safeApprove(IERC20Upgradeable token, address spender, uint256 value) internal {
+        // safeApprove should only be called when setting an initial allowance,
+        // or when resetting it to zero. To increase and decrease it, use
+        // 'safeIncreaseAllowance' and 'safeDecreaseAllowance'
+        // solhint-disable-next-line max-line-length
+        require((value == 0) || (token.allowance(address(this), spender) == 0),
+            "SafeERC20: approve from non-zero to non-zero allowance"
+        );
+        _callOptionalReturn(token, abi.encodeWithSelector(token.approve.selector, spender, value));
+    }
+
+    function safeIncreaseAllowance(IERC20Upgradeable token, address spender, uint256 value) internal {
+        uint256 newAllowance = token.allowance(address(this), spender).add(value);
+        _callOptionalReturn(token, abi.encodeWithSelector(token.approve.selector, spender, newAllowance));
+    }
+
+    function safeDecreaseAllowance(IERC20Upgradeable token, address spender, uint256 value) internal {
+        uint256 newAllowance = token.allowance(address(this), spender).sub(value, "SafeERC20: decreased allowance below zero");
+        _callOptionalReturn(token, abi.encodeWithSelector(token.approve.selector, spender, newAllowance));
+    }
+
+    /**
+     * @dev Imitates a Solidity high-level call (i.e. a regular function call to a contract), relaxing the requirement
+     * on the return value: the return value is optional (but if data is returned, it must not be false).
+     * @param token The token targeted by the call.
+     * @param data The call data (encoded using abi.encode or one of its variants).
+     */
+    function _callOptionalReturn(IERC20Upgradeable token, bytes memory data) private {
+        // We need to perform a low level call here, to bypass Solidity's return data size checking mechanism, since
+        // we're implementing it ourselves. We use {Address.functionCall} to perform this call, which verifies that
+        // the target address contains contract code and also asserts for success in the low-level call.
+
+        bytes memory returndata = address(token).functionCall(data, "SafeERC20: low-level call failed");
+        if (returndata.length > 0) { // Return data is optional
+            // solhint-disable-next-line max-line-length
+            require(abi.decode(returndata, (bool)), "SafeERC20: ERC20 operation did not succeed");
+        }
+    }
+}
+
+
+// File deps/@openzeppelin/contracts-upgradeable/proxy/Initializable.sol
+
+
+
+pragma solidity >=0.4.24 <0.7.0;
+
+
+/**
+ * @dev This is a base contract to aid in writing upgradeable contracts, or any kind of contract that will be deployed
+ * behind a proxy. Since a proxied contract can't have a constructor, it's common to move constructor logic to an
+ * external initializer function, usually called `initialize`. It then becomes necessary to protect this initializer
+ * function so it can only be called once. The {initializer} modifier provided by this contract will have this effect.
+ * 
+ * TIP: To avoid leaving the proxy in an uninitialized state, the initializer function should be called as early as
+ * possible by providing the encoded function call as the `_data` argument to {UpgradeableProxy-constructor}.
+ * 
+ * CAUTION: When used with inheritance, manual care must be taken to not invoke a parent initializer twice, or to ensure
+ * that all initializers are idempotent. This is not verified automatically as constructors are by Solidity.
+ */
+abstract contract Initializable {
+
+    /**
+     * @dev Indicates that the contract has been initialized.
+     */
+    bool private _initialized;
+
+    /**
+     * @dev Indicates that the contract is in the process of being initialized.
+     */
+    bool private _initializing;
+
+    /**
+     * @dev Modifier to protect an initializer function from being invoked twice.
+     */
+    modifier initializer() {
+        require(_initializing || _isConstructor() || !_initialized, "Initializable: contract is already initialized");
+
+        bool isTopLevelCall = !_initializing;
+        if (isTopLevelCall) {
+            _initializing = true;
+            _initialized = true;
+        }
+
+        _;
+
+        if (isTopLevelCall) {
+            _initializing = false;
+        }
+    }
+
+    /// @dev Returns true if and only if the function is running in the constructor
+    function _isConstructor() private view returns (bool) {
+        // extcodesize checks the size of the code stored in an address, and
+        // address returns the current address. Since the code is still not
+        // deployed when running a constructor, any checks on its code size will
+        // yield zero, making it an effective way to detect if a contract is
+        // under construction or not.
+        address self = address(this);
+        uint256 cs;
+        // solhint-disable-next-line no-inline-assembly
+        assembly { cs := extcodesize(self) }
+        return cs == 0;
+    }
+}
+
+
+// File deps/@openzeppelin/contracts-upgradeable/GSN/ContextUpgradeable.sol
+
+
+
+pragma solidity ^0.6.0;
+
+/*
+ * @dev Provides information about the current execution context, including the
+ * sender of the transaction and its data. While these are generally available
+ * via msg.sender and msg.data, they should not be accessed in such a direct
+ * manner, since when dealing with GSN meta-transactions the account sending and
+ * paying for execution may not be the actual sender (as far as an application
+ * is concerned).
+ *
+ * This contract is only required for intermediate, library-like contracts.
+ */
+abstract contract ContextUpgradeable is Initializable {
+    function __Context_init() internal initializer {
+        __Context_init_unchained();
+    }
+
+    function __Context_init_unchained() internal initializer {
+    }
+    function _msgSender() internal view virtual returns (address payable) {
+        return msg.sender;
+    }
+
+    function _msgData() internal view virtual returns (bytes memory) {
+        this; // silence state mutability warning without generating bytecode - see https://github.com/ethereum/solidity/issues/2691
+        return msg.data;
+    }
+    uint256[50] private __gap;
+}
+
+
+// File deps/@openzeppelin/contracts-upgradeable/token/ERC20/ERC20Upgradeable.sol
+
+
+
+pragma solidity ^0.6.0;
+
+
+
+
+
+/**
+ * @dev Implementation of the {IERC20} interface.
+ *
+ * This implementation is agnostic to the way tokens are created. This means
+ * that a supply mechanism has to be added in a derived contract using {_mint}.
+ * For a generic mechanism see {ERC20PresetMinterPauser}.
+ *
+ * TIP: For a detailed writeup see our guide
+ * https://forum.zeppelin.solutions/t/how-to-implement-erc20-supply-mechanisms/226[How
+ * to implement supply mechanisms].
+ *
+ * We have followed general OpenZeppelin guidelines: functions revert instead
+ * of returning `false` on failure. This behavior is nonetheless conventional
+ * and does not conflict with the expectations of ERC20 applications.
+ *
+ * Additionally, an {Approval} event is emitted on calls to {transferFrom}.
+ * This allows applications to reconstruct the allowance for all accounts just
+ * by listening to said events. Other implementations of the EIP may not emit
+ * these events, as it isn't required by the specification.
+ *
+ * Finally, the non-standard {decreaseAllowance} and {increaseAllowance}
+ * functions have been added to mitigate the well-known issues around setting
+ * allowances. See {IERC20-approve}.
+ */
+contract ERC20Upgradeable is Initializable, ContextUpgradeable, IERC20Upgradeable {
+    using SafeMathUpgradeable for uint256;
+    using AddressUpgradeable for address;
+
+    mapping (address => uint256) private _balances;
+
+    mapping (address => mapping (address => uint256)) private _allowances;
+
+    uint256 private _totalSupply;
+
+    string private _name;
+    string private _symbol;
+    uint8 private _decimals;
+
+    /**
+     * @dev Sets the values for {name} and {symbol}, initializes {decimals} with
+     * a default value of 18.
+     *
+     * To select a different value for {decimals}, use {_setupDecimals}.
+     *
+     * All three of these values are immutable: they can only be set once during
+     * construction.
+     */
+    function __ERC20_init(string memory name, string memory symbol) internal initializer {
+        __Context_init_unchained();
+        __ERC20_init_unchained(name, symbol);
+    }
+
+    function __ERC20_init_unchained(string memory name, string memory symbol) internal initializer {
+        _name = name;
+        _symbol = symbol;
+        _decimals = 18;
+    }
+
+    /**
+     * @dev Returns the name of the token.
+     */
+    function name() public view returns (string memory) {
+        return _name;
+    }
+
+    /**
+     * @dev Returns the symbol of the token, usually a shorter version of the
+     * name.
+     */
+    function symbol() public view returns (string memory) {
+        return _symbol;
+    }
+
+    /**
+     * @dev Returns the number of decimals used to get its user representation.
+     * For example, if `decimals` equals `2`, a balance of `505` tokens should
+     * be displayed to a user as `5,05` (`505 / 10 ** 2`).
+     *
+     * Tokens usually opt for a value of 18, imitating the relationship between
+     * Ether and Wei. This is the value {ERC20} uses, unless {_setupDecimals} is
+     * called.
+     *
+     * NOTE: This information is only used for _display_ purposes: it in
+     * no way affects any of the arithmetic of the contract, including
+     * {IERC20-balanceOf} and {IERC20-transfer}.
+     */
+    function decimals() public view returns (uint8) {
+        return _decimals;
+    }
+
+    /**
+     * @dev See {IERC20-totalSupply}.
+     */
+    function totalSupply() public view override returns (uint256) {
+        return _totalSupply;
+    }
+
+    /**
+     * @dev See {IERC20-balanceOf}.
+     */
+    function balanceOf(address account) public view override returns (uint256) {
+        return _balances[account];
+    }
+
+    /**
+     * @dev See {IERC20-transfer}.
+     *
+     * Requirements:
+     *
+     * - `recipient` cannot be the zero address.
+     * - the caller must have a balance of at least `amount`.
+     */
+    function transfer(address recipient, uint256 amount) public virtual override returns (bool) {
+        _transfer(_msgSender(), recipient, amount);
+        return true;
+    }
+
+    /**
+     * @dev See {IERC20-allowance}.
+     */
+    function allowance(address owner, address spender) public view virtual override returns (uint256) {
+        return _allowances[owner][spender];
+    }
+
+    /**
+     * @dev See {IERC20-approve}.
+     *
+     * Requirements:
+     *
+     * - `spender` cannot be the zero address.
+     */
+    function approve(address spender, uint256 amount) public virtual override returns (bool) {
+        _approve(_msgSender(), spender, amount);
+        return true;
+    }
+
+    /**
+     * @dev See {IERC20-transferFrom}.
+     *
+     * Emits an {Approval} event indicating the updated allowance. This is not
+     * required by the EIP. See the note at the beginning of {ERC20};
+     *
+     * Requirements:
+     * - `sender` and `recipient` cannot be the zero address.
+     * - `sender` must have a balance of at least `amount`.
+     * - the caller must have allowance for ``sender``'s tokens of at least
+     * `amount`.
+     */
+    function transferFrom(address sender, address recipient, uint256 amount) public virtual override returns (bool) {
+        _transfer(sender, recipient, amount);
+        _approve(sender, _msgSender(), _allowances[sender][_msgSender()].sub(amount, "ERC20: transfer amount exceeds allowance"));
+        return true;
+    }
+
+    /**
+     * @dev Atomically increases the allowance granted to `spender` by the caller.
+     *
+     * This is an alternative to {approve} that can be used as a mitigation for
+     * problems described in {IERC20-approve}.
+     *
+     * Emits an {Approval} event indicating the updated allowance.
+     *
+     * Requirements:
+     *
+     * - `spender` cannot be the zero address.
+     */
+    function increaseAllowance(address spender, uint256 addedValue) public virtual returns (bool) {
+        _approve(_msgSender(), spender, _allowances[_msgSender()][spender].add(addedValue));
+        return true;
+    }
+
+    /**
+     * @dev Atomically decreases the allowance granted to `spender` by the caller.
+     *
+     * This is an alternative to {approve} that can be used as a mitigation for
+     * problems described in {IERC20-approve}.
+     *
+     * Emits an {Approval} event indicating the updated allowance.
+     *
+     * Requirements:
+     *
+     * - `spender` cannot be the zero address.
+     * - `spender` must have allowance for the caller of at least
+     * `subtractedValue`.
+     */
+    function decreaseAllowance(address spender, uint256 subtractedValue) public virtual returns (bool) {
+        _approve(_msgSender(), spender, _allowances[_msgSender()][spender].sub(subtractedValue, "ERC20: decreased allowance below zero"));
+        return true;
+    }
+
+    /**
+     * @dev Moves tokens `amount` from `sender` to `recipient`.
+     *
+     * This is internal function is equivalent to {transfer}, and can be used to
+     * e.g. implement automatic token fees, slashing mechanisms, etc.
+     *
+     * Emits a {Transfer} event.
+     *
+     * Requirements:
+     *
+     * - `sender` cannot be the zero address.
+     * - `recipient` cannot be the zero address.
+     * - `sender` must have a balance of at least `amount`.
+     */
+    function _transfer(address sender, address recipient, uint256 amount) internal virtual {
+        require(sender != address(0), "ERC20: transfer from the zero address");
+        require(recipient != address(0), "ERC20: transfer to the zero address");
+
+        _beforeTokenTransfer(sender, recipient, amount);
+
+        _balances[sender] = _balances[sender].sub(amount, "ERC20: transfer amount exceeds balance");
+        _balances[recipient] = _balances[recipient].add(amount);
+        emit Transfer(sender, recipient, amount);
+    }
+
+    /** @dev Creates `amount` tokens and assigns them to `account`, increasing
+     * the total supply.
+     *
+     * Emits a {Transfer} event with `from` set to the zero address.
+     *
+     * Requirements
+     *
+     * - `to` cannot be the zero address.
+     */
+    function _mint(address account, uint256 amount) internal virtual {
+        require(account != address(0), "ERC20: mint to the zero address");
+
+        _beforeTokenTransfer(address(0), account, amount);
+
+        _totalSupply = _totalSupply.add(amount);
+        _balances[account] = _balances[account].add(amount);
+        emit Transfer(address(0), account, amount);
+    }
+
+    /**
+     * @dev Destroys `amount` tokens from `account`, reducing the
+     * total supply.
+     *
+     * Emits a {Transfer} event with `to` set to the zero address.
+     *
+     * Requirements
+     *
+     * - `account` cannot be the zero address.
+     * - `account` must have at least `amount` tokens.
+     */
+    function _burn(address account, uint256 amount) internal virtual {
+        require(account != address(0), "ERC20: burn from the zero address");
+
+        _beforeTokenTransfer(account, address(0), amount);
+
+        _balances[account] = _balances[account].sub(amount, "ERC20: burn amount exceeds balance");
+        _totalSupply = _totalSupply.sub(amount);
+        emit Transfer(account, address(0), amount);
+    }
+
+    /**
+     * @dev Sets `amount` as the allowance of `spender` over the `owner` s tokens.
+     *
+     * This internal function is equivalent to `approve`, and can be used to
+     * e.g. set automatic allowances for certain subsystems, etc.
+     *
+     * Emits an {Approval} event.
+     *
+     * Requirements:
+     *
+     * - `owner` cannot be the zero address.
+     * - `spender` cannot be the zero address.
+     */
+    function _approve(address owner, address spender, uint256 amount) internal virtual {
+        require(owner != address(0), "ERC20: approve from the zero address");
+        require(spender != address(0), "ERC20: approve to the zero address");
+
+        _allowances[owner][spender] = amount;
+        emit Approval(owner, spender, amount);
+    }
+
+    /**
+     * @dev Sets {decimals} to a value other than the default one of 18.
+     *
+     * WARNING: This function should only be called from the constructor. Most
+     * applications that interact with token contracts will not expect
+     * {decimals} to ever change, and may work incorrectly if it does.
+     */
+    function _setupDecimals(uint8 decimals_) internal {
+        _decimals = decimals_;
+    }
+
+    /**
+     * @dev Hook that is called before any transfer of tokens. This includes
+     * minting and burning.
+     *
+     * Calling conditions:
+     *
+     * - when `from` and `to` are both non-zero, `amount` of ``from``'s tokens
+     * will be to transferred to `to`.
+     * - when `from` is zero, `amount` tokens will be minted for `to`.
+     * - when `to` is zero, `amount` of ``from``'s tokens will be burned.
+     * - `from` and `to` are never both zero.
+     *
+     * To learn more about hooks, head to xref:ROOT:extending-contracts.adoc#using-hooks[Using Hooks].
+     */
+    function _beforeTokenTransfer(address from, address to, uint256 amount) internal virtual { }
+    uint256[44] private __gap;
+}
+
+
+// File deps/@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol
+
+
+
+pragma solidity ^0.6.0;
+
+
+/**
+ * @dev Contract module which provides a basic access control mechanism, where
+ * there is an account (an owner) that can be granted exclusive access to
+ * specific functions.
+ *
+ * By default, the owner account will be the one that deploys the contract. This
+ * can later be changed with {transferOwnership}.
+ *
+ * This module is used through inheritance. It will make available the modifier
+ * `onlyOwner`, which can be applied to your functions to restrict their use to
+ * the owner.
+ */
+contract OwnableUpgradeable is Initializable, ContextUpgradeable {
+    address private _owner;
+
+    event OwnershipTransferred(address indexed previousOwner, address indexed newOwner);
+
+    /**
+     * @dev Initializes the contract setting the deployer as the initial owner.
+     */
+    function __Ownable_init() internal initializer {
+        __Context_init_unchained();
+        __Ownable_init_unchained();
+    }
+
+    function __Ownable_init_unchained() internal initializer {
+        address msgSender = _msgSender();
+        _owner = msgSender;
+        emit OwnershipTransferred(address(0), msgSender);
+    }
+
+    /**
+     * @dev Returns the address of the current owner.
+     */
+    function owner() public view returns (address) {
+        return _owner;
+    }
+
+    /**
+     * @dev Throws if called by any account other than the owner.
+     */
+    modifier onlyOwner() {
+        require(_owner == _msgSender(), "Ownable: caller is not the owner");
+        _;
+    }
+
+    /**
+     * @dev Leaves the contract without owner. It will not be possible to call
+     * `onlyOwner` functions anymore. Can only be called by the current owner.
+     *
+     * NOTE: Renouncing ownership will leave the contract without an owner,
+     * thereby removing any functionality that is only available to the owner.
+     */
+    function renounceOwnership() public virtual onlyOwner {
+        emit OwnershipTransferred(_owner, address(0));
+        _owner = address(0);
+    }
+
+    /**
+     * @dev Transfers ownership of the contract to a new account (`newOwner`).
+     * Can only be called by the current owner.
+     */
+    function transferOwnership(address newOwner) public virtual onlyOwner {
+        require(newOwner != address(0), "Ownable: new owner is the zero address");
+        emit OwnershipTransferred(_owner, newOwner);
+        _owner = newOwner;
+    }
+    uint256[49] private __gap;
+}
+
+
+// File interfaces/badger/IController.sol
+
+
+pragma solidity >=0.5.0 <0.8.0;
+
+interface IController {
+    function withdraw(address, uint256) external;
+
+    function strategies(address) external view returns (address);
+
+    function balanceOf(address) external view returns (uint256);
+
+    function earn(address, uint256) external;
+
+    function want(address) external view returns (address);
+
+    function rewards() external view returns (address);
+
+    function vaults(address) external view returns (address);
+}
+
+
+// File interfaces/erc20/IERC20Detailed.sol
+
+
+
+pragma solidity ^0.6.0;
+
+/**
+ * @dev Interface of the ERC20 standard as defined in the EIP.
+ */
+interface IERC20Detailed {
+    /**
+     * @dev Returns the amount of tokens in existence.
+     */
+    function totalSupply() external view returns (uint256);
+
+    function name() external view returns (string memory);
+    function symbol() external view returns (string memory);
+
+    /**
+     * @dev Returns the amount of tokens owned by `account`.
+     */
+    function balanceOf(address account) external view returns (uint256);
+
+    /**
+     * @dev Moves `amount` tokens from the caller's account to `recipient`.
+     *
+     * Returns a boolean value indicating whether the operation succeeded.
+     *
+     * Emits a {Transfer} event.
+     */
+    function transfer(address recipient, uint256 amount) external returns (bool);
+
+    /**
+     * @dev Returns the remaining number of tokens that `spender` will be
+     * allowed to spend on behalf of `owner` through {transferFrom}. This is
+     * zero by default.
+     *
+     * This value changes when {approve} or {transferFrom} are called.
+     */
+    function allowance(address owner, address spender) external view returns (uint256);
+
+    /**
+     * @dev Sets `amount` as the allowance of `spender` over the caller's tokens.
+     *
+     * Returns a boolean value indicating whether the operation succeeded.
+     *
+     * IMPORTANT: Beware that changing an allowance with this method brings the risk
+     * that someone may use both the old and the new allowance by unfortunate
+     * transaction ordering. One possible solution to mitigate this race
+     * condition is to first reduce the spender's allowance to 0 and set the
+     * desired value afterwards:
+     * https://github.com/ethereum/EIPs/issues/20#issuecomment-263524729
+     *
+     * Emits an {Approval} event.
+     */
+    function approve(address spender, uint256 amount) external returns (bool);
+
+    /**
+     * @dev Moves `amount` tokens from `sender` to `recipient` using the
+     * allowance mechanism. `amount` is then deducted from the caller's
+     * allowance.
+     *
+     * Returns a boolean value indicating whether the operation succeeded.
+     *
+     * Emits a {Transfer} event.
+     */
+    function transferFrom(address sender, address recipient, uint256 amount) external returns (bool);
+
+    /**
+     * @dev Emitted when `value` tokens are moved from one account (`from`) to
+     * another (`to`).
+     *
+     * Note that `value` may be zero.
+     */
+    event Transfer(address indexed from, address indexed to, uint256 value);
+
+    /**
+     * @dev Emitted when the allowance of a `spender` for an `owner` is set by
+     * a call to {approve}. `value` is the new allowance.
+     */
+    event Approval(address indexed owner, address indexed spender, uint256 value);
+}
+
+
+// File contracts/badger-sett/SettAccessControl.sol
+
+
+pragma solidity ^0.6.11;
+
+/*
+    Common base for permissioned roles throughout Sett ecosystem
+*/
+contract SettAccessControl is Initializable {
+    address public governance;
+    address public strategist;
+    address public keeper;
+
+    // ===== MODIFIERS =====
+    function _onlyGovernance() internal view {
+        require(msg.sender == governance, "onlyGovernance");
+    }
+
+    function _onlyGovernanceOrStrategist() internal view {
+        require(msg.sender == strategist || msg.sender == governance, "onlyGovernanceOrStrategist");
+    }
+
+    function _onlyAuthorizedActors() internal view {
+        require(msg.sender == keeper || msg.sender == governance, "onlyAuthorizedActors");
+    }
+
+    // ===== PERMISSIONED ACTIONS =====
+
+    /// @notice Change strategist address
+    /// @notice Can only be changed by governance itself
+    function setStrategist(address _strategist) external {
+        _onlyGovernance();
+        strategist = _strategist;
+    }
+
+    /// @notice Change keeper address
+    /// @notice Can only be changed by governance itself
+    function setKeeper(address _keeper) external {
+        _onlyGovernance();
+        keeper = _keeper;
+    }
+
+    /// @notice Change governance address
+    /// @notice Can only be changed by governance itself
+    function setGovernance(address _governance) public {
+        _onlyGovernance();
+        governance = _governance;
+    }
+
+    uint256[50] private __gap;
+}
+
+
+// File contracts/badger-sett/SettAccessControlDefended.sol
+
+
+pragma solidity ^0.6.11;
+
+/*
+    Add ability to prevent unwanted contract access to Sett permissions
+*/
+contract SettAccessControlDefended is SettAccessControl {
+    mapping (address => bool) public approved;
+
+    function approveContractAccess(address account) external {
+        _onlyGovernance();
+        approved[account] = true;
+    }
+
+    function revokeContractAccess(address account) external {
+        _onlyGovernance();
+        approved[account] = false;
+    }
+
+    function _defend() internal view returns (bool) {
+        require(approved[msg.sender] || msg.sender == tx.origin, "Access denied for caller");
+    }
+    uint256[50] private __gap;
+}
+
+
+// File contracts/badger-sett/SettV1.sol
+
+
+
+pragma solidity ^0.6.11;
+
+
+
+
+
+
+
+
+/*
+    Source: https://github.com/iearn-finance/yearn-protocol/blob/develop/contracts/vaults/yVault.sol
+
+    This sett contract is for temporarily adding a depositFor() method to V1 setts (e.g. rencrv, tbtc, sbtc etc).
+    TODO: Merge this upgradeable sett into respective sett upgrade path once sett upgrades PR lands.
+*/
+contract SettV1 is ERC20Upgradeable, SettAccessControlDefended {
+    using SafeERC20Upgradeable for IERC20Upgradeable;
+    using AddressUpgradeable for address;
+    using SafeMathUpgradeable for uint256;
+
+    IERC20Upgradeable public token;
+
+    uint256 public min;
+    uint256 public constant max = 10000;
+
+    address public controller;
+
+    mapping(address => uint256) public blockLock;
+
+    string internal constant _defaultNamePrefix = "Badger Sett ";
+    string internal constant _symbolSymbolPrefix = "b";
+
+    event FullPricePerShareUpdated(uint256 value, uint256 indexed timestamp, uint256 indexed blockNumber);
+
+    function initialize(
+        address _token,
+        address _controller,
+        address _governance,
+        address _keeper,
+        bool _overrideTokenName,
+        string memory _namePrefix,
+        string memory _symbolPrefix
+    ) public initializer {
+        IERC20Detailed namedToken = IERC20Detailed(_token);
+        string memory tokenName = namedToken.name();
+        string memory tokenSymbol = namedToken.symbol();
+
+        string memory name;
+        string memory symbol;
+
+        if (_overrideTokenName) {
+            name = string(abi.encodePacked(_namePrefix, tokenName));
+            symbol = string(abi.encodePacked(_symbolPrefix, tokenSymbol));
+        } else {
+            name = string(abi.encodePacked(_defaultNamePrefix, tokenName));
+            symbol = string(abi.encodePacked(_symbolSymbolPrefix, tokenSymbol));
+        }
+
+        __ERC20_init(name, symbol);
+
+        token = IERC20Upgradeable(_token);
+        governance = _governance;
+        strategist = address(0);
+        keeper = _keeper;
+        controller = _controller;
+
+        min = 9500;
+
+        emit FullPricePerShareUpdated(getPricePerFullShare(), now, block.number);
+    }
+
+    /// ===== Modifiers =====
+
+    function _onlyController() internal view {
+        require(msg.sender == controller, "onlyController");
+    }
+
+    function _blockLocked() internal view {
+        require(blockLock[msg.sender] < block.number, "blockLocked");
+    }
+
+    /// ===== View Functions =====
+
+    function getPricePerFullShare() public view returns (uint256) {
+        if (totalSupply() == 0) {
+            return 1e18;
+        }
+        return balance().mul(1e18).div(totalSupply());
+    }
+
+    /// @notice Return the total balance of the underlying token within the system
+    /// @notice Sums the balance in the Sett, the Controller, and the Strategy
+    function balance() public view returns (uint256) {
+        return token.balanceOf(address(this)).add(IController(controller).balanceOf(address(token)));
+    }
+
+    /// @notice Defines how much of the Setts' underlying can be borrowed by the Strategy for use
+    /// @notice Custom logic in here for how much the vault allows to be borrowed
+    /// @notice Sets minimum required on-hand to keep small withdrawals cheap
+    function available() public view returns (uint256) {
+        return token.balanceOf(address(this)).mul(min).div(max);
+    }
+
+    /// ===== Public Actions =====
+
+    /// @notice Deposit assets into the Sett, and return corresponding shares to the user
+    /// @notice Only callable by EOA accounts that pass the _defend() check
+    function deposit(uint256 _amount) public {
+        _defend();
+        _blockLocked();
+
+        _lockForBlock(msg.sender);
+        _deposit(_amount);
+    }
+
+    /// @notice Deposit assets into the Sett, and transfer corresponding shares to the recipient
+    /// @notice Only callable by EOA accounts that pass the _defend() check
+    function depositFor(address recipient, uint256 _amount) public {
+        _defend();
+        _blockLocked();
+
+        // Lock for recipient so receiver cannot perform any other actions within the block.
+        _lockForBlock(recipient);
+        _depositFor(recipient, _amount);
+    }
+
+    /// @notice Convenience function: Deposit entire balance of asset into the Sett, and return corresponding shares to the user
+    /// @notice Only callable by EOA accounts that pass the _defend() check
+    function depositAll() external {
+        _defend();
+        _blockLocked();
+
+        _lockForBlock(msg.sender);
+        _deposit(token.balanceOf(msg.sender));
+    }
+
+    /// @notice No rebalance implementation for lower fees and faster swaps
+    function withdraw(uint256 _shares) public {
+        _defend();
+        _blockLocked();
+
+        _lockForBlock(msg.sender);
+        _withdraw(_shares);
+    }
+
+    /// @notice Convenience function: Withdraw all shares of the sender
+    function withdrawAll() external {
+        _defend();
+        _blockLocked();
+
+        _lockForBlock(msg.sender);
+        _withdraw(balanceOf(msg.sender));
+    }
+
+    /// ===== Permissioned Actions: Governance =====
+
+    /// @notice Set minimum threshold of underlying that must be deposited in strategy
+    /// @notice Can only be changed by governance
+    function setMin(uint256 _min) external {
+        _onlyGovernance();
+        min = _min;
+    }
+
+    /// @notice Change controller address
+    /// @notice Can only be changed by governance
+    function setController(address _controller) public {
+        _onlyGovernance();
+        controller = _controller;
+    }
+
+    /// ===== Permissioned Actions: Controller =====
+
+    /// @notice Used to swap any borrowed reserve over the debt limit to liquidate to 'token'
+    /// @notice Only controller can trigger harvests
+    function harvest(address reserve, uint256 amount) external {
+        _onlyController();
+        require(reserve != address(token), "token");
+        IERC20Upgradeable(reserve).safeTransfer(controller, amount);
+    }
+
+    /// ===== Permissioned Functions: Trusted Actors =====
+
+    /// @notice Transfer the underlying available to be claimed to the controller
+    /// @notice The controller will deposit into the Strategy for yield-generating activities
+    /// @notice Permissionless operation
+    function earn() public {
+        _onlyAuthorizedActors();
+
+        uint256 _bal = available();
+        token.safeTransfer(controller, _bal);
+        IController(controller).earn(address(token), _bal);
+    }
+
+    /// @dev Emit event tracking current full price per share
+    /// @dev Provides a pure on-chain way of approximating APY
+    function trackFullPricePerShare() external {
+        _onlyAuthorizedActors();
+        emit FullPricePerShareUpdated(getPricePerFullShare(), now, block.number);
+    }
+
+    /// ===== Internal Implementations =====
+
+    // @dev deposit for msg.sender
+    function _deposit(uint256 _amount) internal {
+        _depositFor(msg.sender, _amount);
+    }
+
+    /// @dev Calculate the number of shares to issue for a given deposit
+    /// @dev This is based on the realized value of underlying assets between Sett & associated Strategy
+    function _depositFor(address recipient, uint256 _amount) internal {
+        uint256 _pool = balance();
+        uint256 _before = token.balanceOf(address(this));
+        token.safeTransferFrom(msg.sender, address(this), _amount);
+        uint256 _after = token.balanceOf(address(this));
+        _amount = _after.sub(_before); // Additional check for deflationary tokens
+        uint256 shares = 0;
+        if (totalSupply() == 0) {
+            shares = _amount;
+        } else {
+            shares = (_amount.mul(totalSupply())).div(_pool);
+        }
+        _mint(recipient, shares);
+    }
+
+    // No rebalance implementation for lower fees and faster swaps
+    function _withdraw(uint256 _shares) internal {
+        uint256 r = (balance().mul(_shares)).div(totalSupply());
+        _burn(msg.sender, _shares);
+
+        // Check balance
+        uint256 b = token.balanceOf(address(this));
+        if (b < r) {
+            uint256 _toWithdraw = r.sub(b);
+            IController(controller).withdraw(address(token), _toWithdraw);
+            uint256 _after = token.balanceOf(address(this));
+            uint256 _diff = _after.sub(b);
+            if (_diff < _toWithdraw) {
+                r = b.add(_diff);
+            }
+        }
+
+        token.safeTransfer(msg.sender, r);
+    }
+
+    function _lockForBlock(address account) internal {
+        blockLock[account] = block.number;
+    }
+
+    /// ===== ERC20 Overrides =====
+
+    /// @dev Add blockLock to transfers, users cannot transfer tokens in the same block as a deposit or withdrawal.
+    function transfer(address recipient, uint256 amount) public virtual override returns (bool) {
+        _blockLocked();
+        return super.transfer(recipient, amount);
+    }
+
+    function transferFrom(
+        address sender,
+        address recipient,
+        uint256 amount
+    ) public virtual override returns (bool) {
+        _blockLocked();
+        return super.transferFrom(sender, recipient, amount);
+    }
+}

--- a/contracts/_original/SettV1_1.sol
+++ b/contracts/_original/SettV1_1.sol
@@ -1,0 +1,1543 @@
+/**
+ *Submitted for verification at Etherscan.io on 2020-12-27
+*/
+
+// Dependency file: deps/@openzeppelin/contracts-upgradeable/token/ERC20/IERC20Upgradeable.sol
+
+// SPDX-License-Identifier: MIT
+
+// pragma solidity ^0.6.0;
+
+/**
+ * @dev Interface of the ERC20 standard as defined in the EIP.
+ */
+interface IERC20Upgradeable {
+    /**
+     * @dev Returns the amount of tokens in existence.
+     */
+    function totalSupply() external view returns (uint256);
+
+    /**
+     * @dev Returns the amount of tokens owned by `account`.
+     */
+    function balanceOf(address account) external view returns (uint256);
+
+    /**
+     * @dev Moves `amount` tokens from the caller's account to `recipient`.
+     *
+     * Returns a boolean value indicating whether the operation succeeded.
+     *
+     * Emits a {Transfer} event.
+     */
+    function transfer(address recipient, uint256 amount) external returns (bool);
+
+    /**
+     * @dev Returns the remaining number of tokens that `spender` will be
+     * allowed to spend on behalf of `owner` through {transferFrom}. This is
+     * zero by default.
+     *
+     * This value changes when {approve} or {transferFrom} are called.
+     */
+    function allowance(address owner, address spender) external view returns (uint256);
+
+    /**
+     * @dev Sets `amount` as the allowance of `spender` over the caller's tokens.
+     *
+     * Returns a boolean value indicating whether the operation succeeded.
+     *
+     * // importANT: Beware that changing an allowance with this method brings the risk
+     * that someone may use both the old and the new allowance by unfortunate
+     * transaction ordering. One possible solution to mitigate this race
+     * condition is to first reduce the spender's allowance to 0 and set the
+     * desired value afterwards:
+     * https://github.com/ethereum/EIPs/issues/20#issuecomment-263524729
+     *
+     * Emits an {Approval} event.
+     */
+    function approve(address spender, uint256 amount) external returns (bool);
+
+    /**
+     * @dev Moves `amount` tokens from `sender` to `recipient` using the
+     * allowance mechanism. `amount` is then deducted from the caller's
+     * allowance.
+     *
+     * Returns a boolean value indicating whether the operation succeeded.
+     *
+     * Emits a {Transfer} event.
+     */
+    function transferFrom(address sender, address recipient, uint256 amount) external returns (bool);
+
+    /**
+     * @dev Emitted when `value` tokens are moved from one account (`from`) to
+     * another (`to`).
+     *
+     * Note that `value` may be zero.
+     */
+    event Transfer(address indexed from, address indexed to, uint256 value);
+
+    /**
+     * @dev Emitted when the allowance of a `spender` for an `owner` is set by
+     * a call to {approve}. `value` is the new allowance.
+     */
+    event Approval(address indexed owner, address indexed spender, uint256 value);
+}
+
+
+// Dependency file: deps/@openzeppelin/contracts-upgradeable/math/SafeMathUpgradeable.sol
+
+
+// pragma solidity ^0.6.0;
+
+/**
+ * @dev Wrappers over Solidity's arithmetic operations with added overflow
+ * checks.
+ *
+ * Arithmetic operations in Solidity wrap on overflow. This can easily result
+ * in bugs, because programmers usually assume that an overflow raises an
+ * error, which is the standard behavior in high level programming languages.
+ * `SafeMath` restores this intuition by reverting the transaction when an
+ * operation overflows.
+ *
+ * Using this library instead of the unchecked operations eliminates an entire
+ * class of bugs, so it's recommended to use it always.
+ */
+library SafeMathUpgradeable {
+    /**
+     * @dev Returns the addition of two unsigned integers, reverting on
+     * overflow.
+     *
+     * Counterpart to Solidity's `+` operator.
+     *
+     * Requirements:
+     *
+     * - Addition cannot overflow.
+     */
+    function add(uint256 a, uint256 b) internal pure returns (uint256) {
+        uint256 c = a + b;
+        require(c >= a, "SafeMath: addition overflow");
+
+        return c;
+    }
+
+    /**
+     * @dev Returns the subtraction of two unsigned integers, reverting on
+     * overflow (when the result is negative).
+     *
+     * Counterpart to Solidity's `-` operator.
+     *
+     * Requirements:
+     *
+     * - Subtraction cannot overflow.
+     */
+    function sub(uint256 a, uint256 b) internal pure returns (uint256) {
+        return sub(a, b, "SafeMath: subtraction overflow");
+    }
+
+    /**
+     * @dev Returns the subtraction of two unsigned integers, reverting with custom message on
+     * overflow (when the result is negative).
+     *
+     * Counterpart to Solidity's `-` operator.
+     *
+     * Requirements:
+     *
+     * - Subtraction cannot overflow.
+     */
+    function sub(uint256 a, uint256 b, string memory errorMessage) internal pure returns (uint256) {
+        require(b <= a, errorMessage);
+        uint256 c = a - b;
+
+        return c;
+    }
+
+    /**
+     * @dev Returns the multiplication of two unsigned integers, reverting on
+     * overflow.
+     *
+     * Counterpart to Solidity's `*` operator.
+     *
+     * Requirements:
+     *
+     * - Multiplication cannot overflow.
+     */
+    function mul(uint256 a, uint256 b) internal pure returns (uint256) {
+        // Gas optimization: this is cheaper than requiring 'a' not being zero, but the
+        // benefit is lost if 'b' is also tested.
+        // See: https://github.com/OpenZeppelin/openzeppelin-contracts/pull/522
+        if (a == 0) {
+            return 0;
+        }
+
+        uint256 c = a * b;
+        require(c / a == b, "SafeMath: multiplication overflow");
+
+        return c;
+    }
+
+    /**
+     * @dev Returns the integer division of two unsigned integers. Reverts on
+     * division by zero. The result is rounded towards zero.
+     *
+     * Counterpart to Solidity's `/` operator. Note: this function uses a
+     * `revert` opcode (which leaves remaining gas untouched) while Solidity
+     * uses an invalid opcode to revert (consuming all remaining gas).
+     *
+     * Requirements:
+     *
+     * - The divisor cannot be zero.
+     */
+    function div(uint256 a, uint256 b) internal pure returns (uint256) {
+        return div(a, b, "SafeMath: division by zero");
+    }
+
+    /**
+     * @dev Returns the integer division of two unsigned integers. Reverts with custom message on
+     * division by zero. The result is rounded towards zero.
+     *
+     * Counterpart to Solidity's `/` operator. Note: this function uses a
+     * `revert` opcode (which leaves remaining gas untouched) while Solidity
+     * uses an invalid opcode to revert (consuming all remaining gas).
+     *
+     * Requirements:
+     *
+     * - The divisor cannot be zero.
+     */
+    function div(uint256 a, uint256 b, string memory errorMessage) internal pure returns (uint256) {
+        require(b > 0, errorMessage);
+        uint256 c = a / b;
+        // assert(a == b * c + a % b); // There is no case in which this doesn't hold
+
+        return c;
+    }
+
+    /**
+     * @dev Returns the remainder of dividing two unsigned integers. (unsigned integer modulo),
+     * Reverts when dividing by zero.
+     *
+     * Counterpart to Solidity's `%` operator. This function uses a `revert`
+     * opcode (which leaves remaining gas untouched) while Solidity uses an
+     * invalid opcode to revert (consuming all remaining gas).
+     *
+     * Requirements:
+     *
+     * - The divisor cannot be zero.
+     */
+    function mod(uint256 a, uint256 b) internal pure returns (uint256) {
+        return mod(a, b, "SafeMath: modulo by zero");
+    }
+
+    /**
+     * @dev Returns the remainder of dividing two unsigned integers. (unsigned integer modulo),
+     * Reverts with custom message when dividing by zero.
+     *
+     * Counterpart to Solidity's `%` operator. This function uses a `revert`
+     * opcode (which leaves remaining gas untouched) while Solidity uses an
+     * invalid opcode to revert (consuming all remaining gas).
+     *
+     * Requirements:
+     *
+     * - The divisor cannot be zero.
+     */
+    function mod(uint256 a, uint256 b, string memory errorMessage) internal pure returns (uint256) {
+        require(b != 0, errorMessage);
+        return a % b;
+    }
+}
+
+
+// Dependency file: deps/@openzeppelin/contracts-upgradeable/utils/AddressUpgradeable.sol
+
+
+// pragma solidity ^0.6.2;
+
+/**
+ * @dev Collection of functions related to the address type
+ */
+library AddressUpgradeable {
+    /**
+     * @dev Returns true if `account` is a contract.
+     *
+     * [// importANT]
+     * ====
+     * It is unsafe to assume that an address for which this function returns
+     * false is an externally-owned account (EOA) and not a contract.
+     *
+     * Among others, `isContract` will return false for the following
+     * types of addresses:
+     *
+     *  - an externally-owned account
+     *  - a contract in construction
+     *  - an address where a contract will be created
+     *  - an address where a contract lived, but was destroyed
+     * ====
+     */
+    function isContract(address account) internal view returns (bool) {
+        // This method relies in extcodesize, which returns 0 for contracts in
+        // construction, since the code is only stored at the end of the
+        // constructor execution.
+
+        uint256 size;
+        // solhint-disable-next-line no-inline-assembly
+        assembly { size := extcodesize(account) }
+        return size > 0;
+    }
+
+    /**
+     * @dev Replacement for Solidity's `transfer`: sends `amount` wei to
+     * `recipient`, forwarding all available gas and reverting on errors.
+     *
+     * https://eips.ethereum.org/EIPS/eip-1884[EIP1884] increases the gas cost
+     * of certain opcodes, possibly making contracts go over the 2300 gas limit
+     * imposed by `transfer`, making them unable to receive funds via
+     * `transfer`. {sendValue} removes this limitation.
+     *
+     * https://diligence.consensys.net/posts/2019/09/stop-using-soliditys-transfer-now/[Learn more].
+     *
+     * // importANT: because control is transferred to `recipient`, care must be
+     * taken to not create reentrancy vulnerabilities. Consider using
+     * {ReentrancyGuard} or the
+     * https://solidity.readthedocs.io/en/v0.5.11/security-considerations.html#use-the-checks-effects-interactions-pattern[checks-effects-interactions pattern].
+     */
+    function sendValue(address payable recipient, uint256 amount) internal {
+        require(address(this).balance >= amount, "Address: insufficient balance");
+
+        // solhint-disable-next-line avoid-low-level-calls, avoid-call-value
+        (bool success, ) = recipient.call{ value: amount }("");
+        require(success, "Address: unable to send value, recipient may have reverted");
+    }
+
+    /**
+     * @dev Performs a Solidity function call using a low level `call`. A
+     * plain`call` is an unsafe replacement for a function call: use this
+     * function instead.
+     *
+     * If `target` reverts with a revert reason, it is bubbled up by this
+     * function (like regular Solidity function calls).
+     *
+     * Returns the raw returned data. To convert to the expected return value,
+     * use https://solidity.readthedocs.io/en/latest/units-and-global-variables.html?highlight=abi.decode#abi-encoding-and-decoding-functions[`abi.decode`].
+     *
+     * Requirements:
+     *
+     * - `target` must be a contract.
+     * - calling `target` with `data` must not revert.
+     *
+     * _Available since v3.1._
+     */
+    function functionCall(address target, bytes memory data) internal returns (bytes memory) {
+      return functionCall(target, data, "Address: low-level call failed");
+    }
+
+    /**
+     * @dev Same as {xref-Address-functionCall-address-bytes-}[`functionCall`], but with
+     * `errorMessage` as a fallback revert reason when `target` reverts.
+     *
+     * _Available since v3.1._
+     */
+    function functionCall(address target, bytes memory data, string memory errorMessage) internal returns (bytes memory) {
+        return _functionCallWithValue(target, data, 0, errorMessage);
+    }
+
+    /**
+     * @dev Same as {xref-Address-functionCall-address-bytes-}[`functionCall`],
+     * but also transferring `value` wei to `target`.
+     *
+     * Requirements:
+     *
+     * - the calling contract must have an ETH balance of at least `value`.
+     * - the called Solidity function must be `payable`.
+     *
+     * _Available since v3.1._
+     */
+    function functionCallWithValue(address target, bytes memory data, uint256 value) internal returns (bytes memory) {
+        return functionCallWithValue(target, data, value, "Address: low-level call with value failed");
+    }
+
+    /**
+     * @dev Same as {xref-Address-functionCallWithValue-address-bytes-uint256-}[`functionCallWithValue`], but
+     * with `errorMessage` as a fallback revert reason when `target` reverts.
+     *
+     * _Available since v3.1._
+     */
+    function functionCallWithValue(address target, bytes memory data, uint256 value, string memory errorMessage) internal returns (bytes memory) {
+        require(address(this).balance >= value, "Address: insufficient balance for call");
+        return _functionCallWithValue(target, data, value, errorMessage);
+    }
+
+    function _functionCallWithValue(address target, bytes memory data, uint256 weiValue, string memory errorMessage) private returns (bytes memory) {
+        require(isContract(target), "Address: call to non-contract");
+
+        // solhint-disable-next-line avoid-low-level-calls
+        (bool success, bytes memory returndata) = target.call{ value: weiValue }(data);
+        if (success) {
+            return returndata;
+        } else {
+            // Look for revert reason and bubble it up if present
+            if (returndata.length > 0) {
+                // The easiest way to bubble the revert reason is using memory via assembly
+
+                // solhint-disable-next-line no-inline-assembly
+                assembly {
+                    let returndata_size := mload(returndata)
+                    revert(add(32, returndata), returndata_size)
+                }
+            } else {
+                revert(errorMessage);
+            }
+        }
+    }
+}
+
+
+// Dependency file: deps/@openzeppelin/contracts-upgradeable/token/ERC20/SafeERC20Upgradeable.sol
+
+
+// pragma solidity ^0.6.0;
+
+// import "deps/@openzeppelin/contracts-upgradeable/token/ERC20/IERC20Upgradeable.sol";
+// import "deps/@openzeppelin/contracts-upgradeable/math/SafeMathUpgradeable.sol";
+// import "deps/@openzeppelin/contracts-upgradeable/utils/AddressUpgradeable.sol";
+
+/**
+ * @title SafeERC20
+ * @dev Wrappers around ERC20 operations that throw on failure (when the token
+ * contract returns false). Tokens that return no value (and instead revert or
+ * throw on failure) are also supported, non-reverting calls are assumed to be
+ * successful.
+ * To use this library you can add a `using SafeERC20 for IERC20;` statement to your contract,
+ * which allows you to call the safe operations as `token.safeTransfer(...)`, etc.
+ */
+library SafeERC20Upgradeable {
+    using SafeMathUpgradeable for uint256;
+    using AddressUpgradeable for address;
+
+    function safeTransfer(IERC20Upgradeable token, address to, uint256 value) internal {
+        _callOptionalReturn(token, abi.encodeWithSelector(token.transfer.selector, to, value));
+    }
+
+    function safeTransferFrom(IERC20Upgradeable token, address from, address to, uint256 value) internal {
+        _callOptionalReturn(token, abi.encodeWithSelector(token.transferFrom.selector, from, to, value));
+    }
+
+    /**
+     * @dev Deprecated. This function has issues similar to the ones found in
+     * {IERC20-approve}, and its usage is discouraged.
+     *
+     * Whenever possible, use {safeIncreaseAllowance} and
+     * {safeDecreaseAllowance} instead.
+     */
+    function safeApprove(IERC20Upgradeable token, address spender, uint256 value) internal {
+        // safeApprove should only be called when setting an initial allowance,
+        // or when resetting it to zero. To increase and decrease it, use
+        // 'safeIncreaseAllowance' and 'safeDecreaseAllowance'
+        // solhint-disable-next-line max-line-length
+        require((value == 0) || (token.allowance(address(this), spender) == 0),
+            "SafeERC20: approve from non-zero to non-zero allowance"
+        );
+        _callOptionalReturn(token, abi.encodeWithSelector(token.approve.selector, spender, value));
+    }
+
+    function safeIncreaseAllowance(IERC20Upgradeable token, address spender, uint256 value) internal {
+        uint256 newAllowance = token.allowance(address(this), spender).add(value);
+        _callOptionalReturn(token, abi.encodeWithSelector(token.approve.selector, spender, newAllowance));
+    }
+
+    function safeDecreaseAllowance(IERC20Upgradeable token, address spender, uint256 value) internal {
+        uint256 newAllowance = token.allowance(address(this), spender).sub(value, "SafeERC20: decreased allowance below zero");
+        _callOptionalReturn(token, abi.encodeWithSelector(token.approve.selector, spender, newAllowance));
+    }
+
+    /**
+     * @dev Imitates a Solidity high-level call (i.e. a regular function call to a contract), relaxing the requirement
+     * on the return value: the return value is optional (but if data is returned, it must not be false).
+     * @param token The token targeted by the call.
+     * @param data The call data (encoded using abi.encode or one of its variants).
+     */
+    function _callOptionalReturn(IERC20Upgradeable token, bytes memory data) private {
+        // We need to perform a low level call here, to bypass Solidity's return data size checking mechanism, since
+        // we're implementing it ourselves. We use {Address.functionCall} to perform this call, which verifies that
+        // the target address contains contract code and also asserts for success in the low-level call.
+
+        bytes memory returndata = address(token).functionCall(data, "SafeERC20: low-level call failed");
+        if (returndata.length > 0) { // Return data is optional
+            // solhint-disable-next-line max-line-length
+            require(abi.decode(returndata, (bool)), "SafeERC20: ERC20 operation did not succeed");
+        }
+    }
+}
+
+
+// Dependency file: deps/@openzeppelin/contracts-upgradeable/proxy/Initializable.sol
+
+
+// pragma solidity >=0.4.24 <0.7.0;
+
+
+/**
+ * @dev This is a base contract to aid in writing upgradeable contracts, or any kind of contract that will be deployed
+ * behind a proxy. Since a proxied contract can't have a constructor, it's common to move constructor logic to an
+ * external initializer function, usually called `initialize`. It then becomes necessary to protect this initializer
+ * function so it can only be called once. The {initializer} modifier provided by this contract will have this effect.
+ * 
+ * TIP: To avoid leaving the proxy in an uninitialized state, the initializer function should be called as early as
+ * possible by providing the encoded function call as the `_data` argument to {UpgradeableProxy-constructor}.
+ * 
+ * CAUTION: When used with inheritance, manual care must be taken to not invoke a parent initializer twice, or to ensure
+ * that all initializers are idempotent. This is not verified automatically as constructors are by Solidity.
+ */
+abstract contract Initializable {
+
+    /**
+     * @dev Indicates that the contract has been initialized.
+     */
+    bool private _initialized;
+
+    /**
+     * @dev Indicates that the contract is in the process of being initialized.
+     */
+    bool private _initializing;
+
+    /**
+     * @dev Modifier to protect an initializer function from being invoked twice.
+     */
+    modifier initializer() {
+        require(_initializing || _isConstructor() || !_initialized, "Initializable: contract is already initialized");
+
+        bool isTopLevelCall = !_initializing;
+        if (isTopLevelCall) {
+            _initializing = true;
+            _initialized = true;
+        }
+
+        _;
+
+        if (isTopLevelCall) {
+            _initializing = false;
+        }
+    }
+
+    /// @dev Returns true if and only if the function is running in the constructor
+    function _isConstructor() private view returns (bool) {
+        // extcodesize checks the size of the code stored in an address, and
+        // address returns the current address. Since the code is still not
+        // deployed when running a constructor, any checks on its code size will
+        // yield zero, making it an effective way to detect if a contract is
+        // under construction or not.
+        address self = address(this);
+        uint256 cs;
+        // solhint-disable-next-line no-inline-assembly
+        assembly { cs := extcodesize(self) }
+        return cs == 0;
+    }
+}
+
+
+// Dependency file: deps/@openzeppelin/contracts-upgradeable/GSN/ContextUpgradeable.sol
+
+
+// pragma solidity ^0.6.0;
+// import "deps/@openzeppelin/contracts-upgradeable/proxy/Initializable.sol";
+
+/*
+ * @dev Provides information about the current execution context, including the
+ * sender of the transaction and its data. While these are generally available
+ * via msg.sender and msg.data, they should not be accessed in such a direct
+ * manner, since when dealing with GSN meta-transactions the account sending and
+ * paying for execution may not be the actual sender (as far as an application
+ * is concerned).
+ *
+ * This contract is only required for intermediate, library-like contracts.
+ */
+abstract contract ContextUpgradeable is Initializable {
+    function __Context_init() internal initializer {
+        __Context_init_unchained();
+    }
+
+    function __Context_init_unchained() internal initializer {
+    }
+    function _msgSender() internal view virtual returns (address payable) {
+        return msg.sender;
+    }
+
+    function _msgData() internal view virtual returns (bytes memory) {
+        this; // silence state mutability warning without generating bytecode - see https://github.com/ethereum/solidity/issues/2691
+        return msg.data;
+    }
+    uint256[50] private __gap;
+}
+
+
+// Dependency file: deps/@openzeppelin/contracts-upgradeable/token/ERC20/ERC20Upgradeable.sol
+
+
+// pragma solidity ^0.6.0;
+
+// import "deps/@openzeppelin/contracts-upgradeable/GSN/ContextUpgradeable.sol";
+// import "deps/@openzeppelin/contracts-upgradeable/token/ERC20/IERC20Upgradeable.sol";
+// import "deps/@openzeppelin/contracts-upgradeable/math/SafeMathUpgradeable.sol";
+// import "deps/@openzeppelin/contracts-upgradeable/utils/AddressUpgradeable.sol";
+// import "deps/@openzeppelin/contracts-upgradeable/proxy/Initializable.sol";
+
+/**
+ * @dev Implementation of the {IERC20} interface.
+ *
+ * This implementation is agnostic to the way tokens are created. This means
+ * that a supply mechanism has to be added in a derived contract using {_mint}.
+ * For a generic mechanism see {ERC20PresetMinterPauser}.
+ *
+ * TIP: For a detailed writeup see our guide
+ * https://forum.zeppelin.solutions/t/how-to-implement-erc20-supply-mechanisms/226[How
+ * to implement supply mechanisms].
+ *
+ * We have followed general OpenZeppelin guidelines: functions revert instead
+ * of returning `false` on failure. This behavior is nonetheless conventional
+ * and does not conflict with the expectations of ERC20 applications.
+ *
+ * Additionally, an {Approval} event is emitted on calls to {transferFrom}.
+ * This allows applications to reconstruct the allowance for all accounts just
+ * by listening to said events. Other implementations of the EIP may not emit
+ * these events, as it isn't required by the specification.
+ *
+ * Finally, the non-standard {decreaseAllowance} and {increaseAllowance}
+ * functions have been added to mitigate the well-known issues around setting
+ * allowances. See {IERC20-approve}.
+ */
+contract ERC20Upgradeable is Initializable, ContextUpgradeable, IERC20Upgradeable {
+    using SafeMathUpgradeable for uint256;
+    using AddressUpgradeable for address;
+
+    mapping (address => uint256) private _balances;
+
+    mapping (address => mapping (address => uint256)) private _allowances;
+
+    uint256 private _totalSupply;
+
+    string private _name;
+    string private _symbol;
+    uint8 private _decimals;
+
+    /**
+     * @dev Sets the values for {name} and {symbol}, initializes {decimals} with
+     * a default value of 18.
+     *
+     * To select a different value for {decimals}, use {_setupDecimals}.
+     *
+     * All three of these values are immutable: they can only be set once during
+     * construction.
+     */
+    function __ERC20_init(string memory name, string memory symbol) internal initializer {
+        __Context_init_unchained();
+        __ERC20_init_unchained(name, symbol);
+    }
+
+    function __ERC20_init_unchained(string memory name, string memory symbol) internal initializer {
+        _name = name;
+        _symbol = symbol;
+        _decimals = 18;
+    }
+
+    /**
+     * @dev Returns the name of the token.
+     */
+    function name() public view returns (string memory) {
+        return _name;
+    }
+
+    /**
+     * @dev Returns the symbol of the token, usually a shorter version of the
+     * name.
+     */
+    function symbol() public view returns (string memory) {
+        return _symbol;
+    }
+
+    /**
+     * @dev Returns the number of decimals used to get its user representation.
+     * For example, if `decimals` equals `2`, a balance of `505` tokens should
+     * be displayed to a user as `5,05` (`505 / 10 ** 2`).
+     *
+     * Tokens usually opt for a value of 18, imitating the relationship between
+     * Ether and Wei. This is the value {ERC20} uses, unless {_setupDecimals} is
+     * called.
+     *
+     * NOTE: This information is only used for _display_ purposes: it in
+     * no way affects any of the arithmetic of the contract, including
+     * {IERC20-balanceOf} and {IERC20-transfer}.
+     */
+    function decimals() public view returns (uint8) {
+        return _decimals;
+    }
+
+    /**
+     * @dev See {IERC20-totalSupply}.
+     */
+    function totalSupply() public view override returns (uint256) {
+        return _totalSupply;
+    }
+
+    /**
+     * @dev See {IERC20-balanceOf}.
+     */
+    function balanceOf(address account) public view override returns (uint256) {
+        return _balances[account];
+    }
+
+    /**
+     * @dev See {IERC20-transfer}.
+     *
+     * Requirements:
+     *
+     * - `recipient` cannot be the zero address.
+     * - the caller must have a balance of at least `amount`.
+     */
+    function transfer(address recipient, uint256 amount) public virtual override returns (bool) {
+        _transfer(_msgSender(), recipient, amount);
+        return true;
+    }
+
+    /**
+     * @dev See {IERC20-allowance}.
+     */
+    function allowance(address owner, address spender) public view virtual override returns (uint256) {
+        return _allowances[owner][spender];
+    }
+
+    /**
+     * @dev See {IERC20-approve}.
+     *
+     * Requirements:
+     *
+     * - `spender` cannot be the zero address.
+     */
+    function approve(address spender, uint256 amount) public virtual override returns (bool) {
+        _approve(_msgSender(), spender, amount);
+        return true;
+    }
+
+    /**
+     * @dev See {IERC20-transferFrom}.
+     *
+     * Emits an {Approval} event indicating the updated allowance. This is not
+     * required by the EIP. See the note at the beginning of {ERC20};
+     *
+     * Requirements:
+     * - `sender` and `recipient` cannot be the zero address.
+     * - `sender` must have a balance of at least `amount`.
+     * - the caller must have allowance for ``sender``'s tokens of at least
+     * `amount`.
+     */
+    function transferFrom(address sender, address recipient, uint256 amount) public virtual override returns (bool) {
+        _transfer(sender, recipient, amount);
+        _approve(sender, _msgSender(), _allowances[sender][_msgSender()].sub(amount, "ERC20: transfer amount exceeds allowance"));
+        return true;
+    }
+
+    /**
+     * @dev Atomically increases the allowance granted to `spender` by the caller.
+     *
+     * This is an alternative to {approve} that can be used as a mitigation for
+     * problems described in {IERC20-approve}.
+     *
+     * Emits an {Approval} event indicating the updated allowance.
+     *
+     * Requirements:
+     *
+     * - `spender` cannot be the zero address.
+     */
+    function increaseAllowance(address spender, uint256 addedValue) public virtual returns (bool) {
+        _approve(_msgSender(), spender, _allowances[_msgSender()][spender].add(addedValue));
+        return true;
+    }
+
+    /**
+     * @dev Atomically decreases the allowance granted to `spender` by the caller.
+     *
+     * This is an alternative to {approve} that can be used as a mitigation for
+     * problems described in {IERC20-approve}.
+     *
+     * Emits an {Approval} event indicating the updated allowance.
+     *
+     * Requirements:
+     *
+     * - `spender` cannot be the zero address.
+     * - `spender` must have allowance for the caller of at least
+     * `subtractedValue`.
+     */
+    function decreaseAllowance(address spender, uint256 subtractedValue) public virtual returns (bool) {
+        _approve(_msgSender(), spender, _allowances[_msgSender()][spender].sub(subtractedValue, "ERC20: decreased allowance below zero"));
+        return true;
+    }
+
+    /**
+     * @dev Moves tokens `amount` from `sender` to `recipient`.
+     *
+     * This is internal function is equivalent to {transfer}, and can be used to
+     * e.g. implement automatic token fees, slashing mechanisms, etc.
+     *
+     * Emits a {Transfer} event.
+     *
+     * Requirements:
+     *
+     * - `sender` cannot be the zero address.
+     * - `recipient` cannot be the zero address.
+     * - `sender` must have a balance of at least `amount`.
+     */
+    function _transfer(address sender, address recipient, uint256 amount) internal virtual {
+        require(sender != address(0), "ERC20: transfer from the zero address");
+        require(recipient != address(0), "ERC20: transfer to the zero address");
+
+        _beforeTokenTransfer(sender, recipient, amount);
+
+        _balances[sender] = _balances[sender].sub(amount, "ERC20: transfer amount exceeds balance");
+        _balances[recipient] = _balances[recipient].add(amount);
+        emit Transfer(sender, recipient, amount);
+    }
+
+    /** @dev Creates `amount` tokens and assigns them to `account`, increasing
+     * the total supply.
+     *
+     * Emits a {Transfer} event with `from` set to the zero address.
+     *
+     * Requirements
+     *
+     * - `to` cannot be the zero address.
+     */
+    function _mint(address account, uint256 amount) internal virtual {
+        require(account != address(0), "ERC20: mint to the zero address");
+
+        _beforeTokenTransfer(address(0), account, amount);
+
+        _totalSupply = _totalSupply.add(amount);
+        _balances[account] = _balances[account].add(amount);
+        emit Transfer(address(0), account, amount);
+    }
+
+    /**
+     * @dev Destroys `amount` tokens from `account`, reducing the
+     * total supply.
+     *
+     * Emits a {Transfer} event with `to` set to the zero address.
+     *
+     * Requirements
+     *
+     * - `account` cannot be the zero address.
+     * - `account` must have at least `amount` tokens.
+     */
+    function _burn(address account, uint256 amount) internal virtual {
+        require(account != address(0), "ERC20: burn from the zero address");
+
+        _beforeTokenTransfer(account, address(0), amount);
+
+        _balances[account] = _balances[account].sub(amount, "ERC20: burn amount exceeds balance");
+        _totalSupply = _totalSupply.sub(amount);
+        emit Transfer(account, address(0), amount);
+    }
+
+    /**
+     * @dev Sets `amount` as the allowance of `spender` over the `owner` s tokens.
+     *
+     * This internal function is equivalent to `approve`, and can be used to
+     * e.g. set automatic allowances for certain subsystems, etc.
+     *
+     * Emits an {Approval} event.
+     *
+     * Requirements:
+     *
+     * - `owner` cannot be the zero address.
+     * - `spender` cannot be the zero address.
+     */
+    function _approve(address owner, address spender, uint256 amount) internal virtual {
+        require(owner != address(0), "ERC20: approve from the zero address");
+        require(spender != address(0), "ERC20: approve to the zero address");
+
+        _allowances[owner][spender] = amount;
+        emit Approval(owner, spender, amount);
+    }
+
+    /**
+     * @dev Sets {decimals} to a value other than the default one of 18.
+     *
+     * WARNING: This function should only be called from the constructor. Most
+     * applications that interact with token contracts will not expect
+     * {decimals} to ever change, and may work incorrectly if it does.
+     */
+    function _setupDecimals(uint8 decimals_) internal {
+        _decimals = decimals_;
+    }
+
+    /**
+     * @dev Hook that is called before any transfer of tokens. This includes
+     * minting and burning.
+     *
+     * Calling conditions:
+     *
+     * - when `from` and `to` are both non-zero, `amount` of ``from``'s tokens
+     * will be to transferred to `to`.
+     * - when `from` is zero, `amount` tokens will be minted for `to`.
+     * - when `to` is zero, `amount` of ``from``'s tokens will be burned.
+     * - `from` and `to` are never both zero.
+     *
+     * To learn more about hooks, head to xref:ROOT:extending-contracts.adoc#using-hooks[Using Hooks].
+     */
+    function _beforeTokenTransfer(address from, address to, uint256 amount) internal virtual { }
+    uint256[44] private __gap;
+}
+
+
+// Dependency file: deps/@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol
+
+
+// pragma solidity ^0.6.0;
+
+// import "deps/@openzeppelin/contracts-upgradeable/GSN/ContextUpgradeable.sol";
+// import "deps/@openzeppelin/contracts-upgradeable/proxy/Initializable.sol";
+/**
+ * @dev Contract module which provides a basic access control mechanism, where
+ * there is an account (an owner) that can be granted exclusive access to
+ * specific functions.
+ *
+ * By default, the owner account will be the one that deploys the contract. This
+ * can later be changed with {transferOwnership}.
+ *
+ * This module is used through inheritance. It will make available the modifier
+ * `onlyOwner`, which can be applied to your functions to restrict their use to
+ * the owner.
+ */
+contract OwnableUpgradeable is Initializable, ContextUpgradeable {
+    address private _owner;
+
+    event OwnershipTransferred(address indexed previousOwner, address indexed newOwner);
+
+    /**
+     * @dev Initializes the contract setting the deployer as the initial owner.
+     */
+    function __Ownable_init() internal initializer {
+        __Context_init_unchained();
+        __Ownable_init_unchained();
+    }
+
+    function __Ownable_init_unchained() internal initializer {
+        address msgSender = _msgSender();
+        _owner = msgSender;
+        emit OwnershipTransferred(address(0), msgSender);
+    }
+
+    /**
+     * @dev Returns the address of the current owner.
+     */
+    function owner() public view returns (address) {
+        return _owner;
+    }
+
+    /**
+     * @dev Throws if called by any account other than the owner.
+     */
+    modifier onlyOwner() {
+        require(_owner == _msgSender(), "Ownable: caller is not the owner");
+        _;
+    }
+
+    /**
+     * @dev Leaves the contract without owner. It will not be possible to call
+     * `onlyOwner` functions anymore. Can only be called by the current owner.
+     *
+     * NOTE: Renouncing ownership will leave the contract without an owner,
+     * thereby removing any functionality that is only available to the owner.
+     */
+    function renounceOwnership() public virtual onlyOwner {
+        emit OwnershipTransferred(_owner, address(0));
+        _owner = address(0);
+    }
+
+    /**
+     * @dev Transfers ownership of the contract to a new account (`newOwner`).
+     * Can only be called by the current owner.
+     */
+    function transferOwnership(address newOwner) public virtual onlyOwner {
+        require(newOwner != address(0), "Ownable: new owner is the zero address");
+        emit OwnershipTransferred(_owner, newOwner);
+        _owner = newOwner;
+    }
+    uint256[49] private __gap;
+}
+
+
+// Dependency file: deps/@openzeppelin/contracts-upgradeable/utils/PausableUpgradeable.sol
+
+
+// pragma solidity ^0.6.0;
+
+// import "deps/@openzeppelin/contracts-upgradeable/GSN/ContextUpgradeable.sol";
+// import "deps/@openzeppelin/contracts-upgradeable/proxy/Initializable.sol";
+
+/**
+ * @dev Contract module which allows children to implement an emergency stop
+ * mechanism that can be triggered by an authorized account.
+ *
+ * This module is used through inheritance. It will make available the
+ * modifiers `whenNotPaused` and `whenPaused`, which can be applied to
+ * the functions of your contract. Note that they will not be pausable by
+ * simply including this module, only once the modifiers are put in place.
+ */
+contract PausableUpgradeable is Initializable, ContextUpgradeable {
+    /**
+     * @dev Emitted when the pause is triggered by `account`.
+     */
+    event Paused(address account);
+
+    /**
+     * @dev Emitted when the pause is lifted by `account`.
+     */
+    event Unpaused(address account);
+
+    bool private _paused;
+
+    /**
+     * @dev Initializes the contract in unpaused state.
+     */
+    function __Pausable_init() internal initializer {
+        __Context_init_unchained();
+        __Pausable_init_unchained();
+    }
+
+    function __Pausable_init_unchained() internal initializer {
+        _paused = false;
+    }
+
+    /**
+     * @dev Returns true if the contract is paused, and false otherwise.
+     */
+    function paused() public view returns (bool) {
+        return _paused;
+    }
+
+    /**
+     * @dev Modifier to make a function callable only when the contract is not paused.
+     *
+     * Requirements:
+     *
+     * - The contract must not be paused.
+     */
+    modifier whenNotPaused() {
+        require(!_paused, "Pausable: paused");
+        _;
+    }
+
+    /**
+     * @dev Modifier to make a function callable only when the contract is paused.
+     *
+     * Requirements:
+     *
+     * - The contract must be paused.
+     */
+    modifier whenPaused() {
+        require(_paused, "Pausable: not paused");
+        _;
+    }
+
+    /**
+     * @dev Triggers stopped state.
+     *
+     * Requirements:
+     *
+     * - The contract must not be paused.
+     */
+    function _pause() internal virtual whenNotPaused {
+        _paused = true;
+        emit Paused(_msgSender());
+    }
+
+    /**
+     * @dev Returns to normal state.
+     *
+     * Requirements:
+     *
+     * - The contract must be paused.
+     */
+    function _unpause() internal virtual whenPaused {
+        _paused = false;
+        emit Unpaused(_msgSender());
+    }
+    uint256[49] private __gap;
+}
+
+
+// Dependency file: interfaces/badger/IController.sol
+
+// pragma solidity >=0.5.0 <0.8.0;
+
+interface IController {
+    function withdraw(address, uint256) external;
+
+    function balanceOf(address) external view returns (uint256);
+
+    function earn(address, uint256) external;
+
+    function want(address) external view returns (address);
+
+    function rewards() external view returns (address);
+
+    function vaults(address) external view returns (address);
+}
+
+
+// Dependency file: interfaces/erc20/IERC20Detailed.sol
+
+
+// pragma solidity ^0.6.0;
+
+/**
+ * @dev Interface of the ERC20 standard as defined in the EIP.
+ */
+interface IERC20Detailed {
+    /**
+     * @dev Returns the amount of tokens in existence.
+     */
+    function totalSupply() external view returns (uint256);
+
+    function name() external view returns (string memory);
+    function symbol() external view returns (string memory);
+
+    /**
+     * @dev Returns the amount of tokens owned by `account`.
+     */
+    function balanceOf(address account) external view returns (uint256);
+
+    /**
+     * @dev Moves `amount` tokens from the caller's account to `recipient`.
+     *
+     * Returns a boolean value indicating whether the operation succeeded.
+     *
+     * Emits a {Transfer} event.
+     */
+    function transfer(address recipient, uint256 amount) external returns (bool);
+
+    /**
+     * @dev Returns the remaining number of tokens that `spender` will be
+     * allowed to spend on behalf of `owner` through {transferFrom}. This is
+     * zero by default.
+     *
+     * This value changes when {approve} or {transferFrom} are called.
+     */
+    function allowance(address owner, address spender) external view returns (uint256);
+
+    /**
+     * @dev Sets `amount` as the allowance of `spender` over the caller's tokens.
+     *
+     * Returns a boolean value indicating whether the operation succeeded.
+     *
+     * // importANT: Beware that changing an allowance with this method brings the risk
+     * that someone may use both the old and the new allowance by unfortunate
+     * transaction ordering. One possible solution to mitigate this race
+     * condition is to first reduce the spender's allowance to 0 and set the
+     * desired value afterwards:
+     * https://github.com/ethereum/EIPs/issues/20#issuecomment-263524729
+     *
+     * Emits an {Approval} event.
+     */
+    function approve(address spender, uint256 amount) external returns (bool);
+
+    /**
+     * @dev Moves `amount` tokens from `sender` to `recipient` using the
+     * allowance mechanism. `amount` is then deducted from the caller's
+     * allowance.
+     *
+     * Returns a boolean value indicating whether the operation succeeded.
+     *
+     * Emits a {Transfer} event.
+     */
+    function transferFrom(address sender, address recipient, uint256 amount) external returns (bool);
+
+    /**
+     * @dev Emitted when `value` tokens are moved from one account (`from`) to
+     * another (`to`).
+     *
+     * Note that `value` may be zero.
+     */
+    event Transfer(address indexed from, address indexed to, uint256 value);
+
+    /**
+     * @dev Emitted when the allowance of a `spender` for an `owner` is set by
+     * a call to {approve}. `value` is the new allowance.
+     */
+    event Approval(address indexed owner, address indexed spender, uint256 value);
+}
+
+
+// Dependency file: contracts/badger-sett/SettAccessControl.sol
+
+// pragma solidity ^0.6.11;
+
+// import "deps/@openzeppelin/contracts-upgradeable/proxy/Initializable.sol";
+
+/*
+    Common base for permissioned roles throughout Sett ecosystem
+*/
+contract SettAccessControl is Initializable {
+    address public governance;
+    address public strategist;
+    address public keeper;
+
+    // ===== MODIFIERS =====
+    function _onlyGovernance() internal view {
+        require(msg.sender == governance, "onlyGovernance");
+    }
+
+    function _onlyGovernanceOrStrategist() internal view {
+        require(msg.sender == strategist || msg.sender == governance, "onlyGovernanceOrStrategist");
+    }
+
+    function _onlyAuthorizedActors() internal view {
+        require(msg.sender == keeper || msg.sender == governance, "onlyAuthorizedActors");
+    }
+
+    // ===== PERMISSIONED ACTIONS =====
+
+    /// @notice Change strategist address
+    /// @notice Can only be changed by governance itself
+    function setStrategist(address _strategist) external {
+        _onlyGovernance();
+        strategist = _strategist;
+    }
+
+    /// @notice Change keeper address
+    /// @notice Can only be changed by governance itself
+    function setKeeper(address _keeper) external {
+        _onlyGovernance();
+        keeper = _keeper;
+    }
+
+    /// @notice Change governance address
+    /// @notice Can only be changed by governance itself
+    function setGovernance(address _governance) public {
+        _onlyGovernance();
+        governance = _governance;
+    }
+
+    uint256[50] private __gap;
+}
+
+
+// Dependency file: contracts/badger-sett/SettAccessControlDefended.sol
+
+// pragma solidity ^0.6.11;
+
+// import "contracts/badger-sett/SettAccessControl.sol";
+
+/*
+    Add ability to prevent unwanted contract access to Sett permissions
+*/
+contract SettAccessControlDefended is SettAccessControl {
+    mapping (address => bool) public approved;
+
+    function approveContractAccess(address account) external {
+        _onlyGovernance();
+        approved[account] = true;
+    }
+
+    function revokeContractAccess(address account) external {
+        _onlyGovernance();
+        approved[account] = false;
+    }
+
+    function _defend() internal view returns (bool) {
+        require(approved[msg.sender] || msg.sender == tx.origin, "Access denied for caller");
+    }
+    uint256[50] private __gap;
+}
+
+
+// Root file: contracts/badger-sett/Sett.sol
+
+
+pragma solidity ^0.6.11;
+
+// import "deps/@openzeppelin/contracts-upgradeable/token/ERC20/IERC20Upgradeable.sol";
+// import "deps/@openzeppelin/contracts-upgradeable/math/SafeMathUpgradeable.sol";
+// import "deps/@openzeppelin/contracts-upgradeable/utils/AddressUpgradeable.sol";
+// import "deps/@openzeppelin/contracts-upgradeable/token/ERC20/SafeERC20Upgradeable.sol";
+// import "deps/@openzeppelin/contracts-upgradeable/token/ERC20/ERC20Upgradeable.sol";
+// import "deps/@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
+// import "deps/@openzeppelin/contracts-upgradeable/utils/PausableUpgradeable.sol";
+
+// import "interfaces/badger/IController.sol";
+// import "interfaces/erc20/IERC20Detailed.sol";
+// import "contracts/badger-sett/SettAccessControlDefended.sol";
+
+/* 
+    Source: https://github.com/iearn-finance/yearn-protocol/blob/develop/contracts/vaults/yVault.sol
+
+    Version 1.1
+    * Strategist no longer has special function calling permissions
+    * Version function added to contract
+    * All write functions are pausable
+    * Keeper or governance can pause
+    * Only governance can unpause
+    * Governance, by maintaining upgradability rights, can remove the keepers' ability to pause
+*/
+contract Sett is ERC20Upgradeable, PausableUpgradeable, SettAccessControlDefended {
+    using SafeERC20Upgradeable for IERC20Upgradeable;
+    using AddressUpgradeable for address;
+    using SafeMathUpgradeable for uint256;
+
+    IERC20Upgradeable public token;
+
+    uint256 public min;
+    uint256 public constant max = 10000;
+
+    address public controller;
+    address public guardian;
+
+    mapping(address => uint256) public blockLock;
+
+    string internal constant _defaultNamePrefix = "Badger Sett ";
+    string internal constant _symbolSymbolPrefix = "b";
+
+    event FullPricePerShareUpdated(uint256 value, uint256 indexed timestamp, uint256 indexed blockNumber);
+
+    function initialize(
+        address _token,
+        address _controller,
+        address _governance,
+        address _keeper,
+        address _guardian,
+        bool _overrideTokenName,
+        string memory _namePrefix,
+        string memory _symbolPrefix
+    ) public initializer whenNotPaused {
+        IERC20Detailed namedToken = IERC20Detailed(_token);
+        string memory tokenName = namedToken.name();
+        string memory tokenSymbol = namedToken.symbol();
+
+        string memory name;
+        string memory symbol;
+
+        if (_overrideTokenName) {
+            name = string(abi.encodePacked(_namePrefix, tokenName));
+            symbol = string(abi.encodePacked(_symbolPrefix, tokenSymbol));
+        } else {
+            name = string(abi.encodePacked(_defaultNamePrefix, tokenName));
+            symbol = string(abi.encodePacked(_symbolSymbolPrefix, tokenSymbol));
+        }
+
+        __ERC20_init(name, symbol);
+
+        token = IERC20Upgradeable(_token);
+        governance = _governance;
+        strategist = address(0);
+        keeper = _keeper;
+        controller = _controller;
+        guardian = _guardian;
+
+        min = 9500;
+
+        emit FullPricePerShareUpdated(getPricePerFullShare(), now, block.number);
+
+        // Paused on launch
+        _pause();
+    }
+
+    /// ===== Modifiers =====
+
+    function _onlyController() internal view {
+        require(msg.sender == controller, "onlyController");
+    }
+
+    function _onlyAuthorizedPausers() internal view {
+        require(msg.sender == guardian || msg.sender == governance, "onlyPausers");
+    }
+
+    function _blockLocked() internal view {
+        require(blockLock[msg.sender] < block.number, "blockLocked");
+    }
+
+    /// ===== View Functions =====
+
+    function version() public view returns (string memory) {
+        return "1.1";
+    }
+
+    function getPricePerFullShare() public view returns (uint256) {
+        if (totalSupply() == 0) {
+            return 1e18;
+        }
+        return balance().mul(1e18).div(totalSupply());
+    }
+
+    /// @notice Return the total balance of the underlying token within the system
+    /// @notice Sums the balance in the Sett, the Controller, and the Strategy
+    function balance() public view returns (uint256) {
+        return token.balanceOf(address(this)).add(IController(controller).balanceOf(address(token)));
+    }
+
+    /// @notice Defines how much of the Setts' underlying can be borrowed by the Strategy for use
+    /// @notice Custom logic in here for how much the vault allows to be borrowed
+    /// @notice Sets minimum required on-hand to keep small withdrawals cheap
+    function available() public view returns (uint256) {
+        return token.balanceOf(address(this)).mul(min).div(max);
+    }
+
+    /// ===== Public Actions =====
+
+    /// @notice Deposit assets into the Sett, and return corresponding shares to the user
+    /// @notice Only callable by EOA accounts that pass the _defend() check
+    function deposit(uint256 _amount) public whenNotPaused {
+        _defend();
+        _blockLocked();
+
+        _lockForBlock(msg.sender);
+        _deposit(_amount);
+    }
+
+    /// @notice Convenience function: Deposit entire balance of asset into the Sett, and return corresponding shares to the user
+    /// @notice Only callable by EOA accounts that pass the _defend() check
+    function depositAll() external whenNotPaused {
+        _defend();
+        _blockLocked();
+
+        _lockForBlock(msg.sender);
+        _deposit(token.balanceOf(msg.sender));
+    }
+
+    /// @notice No rebalance implementation for lower fees and faster swaps
+    function withdraw(uint256 _shares) public whenNotPaused {
+        _defend();
+        _blockLocked();
+
+        _lockForBlock(msg.sender);
+        _withdraw(_shares);
+    }
+
+    /// @notice Convenience function: Withdraw all shares of the sender
+    function withdrawAll() external whenNotPaused {
+        _defend();
+        _blockLocked();
+
+        _lockForBlock(msg.sender);
+        _withdraw(balanceOf(msg.sender));
+    }
+
+    /// ===== Permissioned Actions: Governance =====
+
+    /// @notice Set minimum threshold of underlying that must be deposited in strategy
+    /// @notice Can only be changed by governance
+    function setMin(uint256 _min) external {
+        _onlyGovernance();
+        min = _min;
+    }
+
+    /// @notice Change controller address
+    /// @notice Can only be changed by governance
+    function setController(address _controller) public {
+        _onlyGovernance();
+        controller = _controller;
+    }
+
+    /// @notice Change guardian address
+    /// @notice Can only be changed by governance
+    function setGuardian(address _guardian) external {
+        _onlyGovernance();
+        guardian = _guardian;
+    }
+
+
+    /// ===== Permissioned Actions: Controller =====
+
+    /// @notice Used to swap any borrowed reserve over the debt limit to liquidate to 'token'
+    /// @notice Only controller can trigger harvests
+    function harvest(address reserve, uint256 amount) external whenNotPaused {
+        _onlyController();
+        require(reserve != address(token), "token");
+        IERC20Upgradeable(reserve).safeTransfer(controller, amount);
+    }
+
+    /// ===== Permissioned Functions: Trusted Actors =====
+
+    /// @notice Transfer the underlying available to be claimed to the controller
+    /// @notice The controller will deposit into the Strategy for yield-generating activities
+    /// @notice Permissionless operation
+    function earn() public whenNotPaused {
+        _onlyAuthorizedActors();
+
+        uint256 _bal = available();
+        token.safeTransfer(controller, _bal);
+        IController(controller).earn(address(token), _bal);
+    }
+
+    /// @dev Emit event tracking current full price per share
+    /// @dev Provides a pure on-chain way of approximating APY
+    function trackFullPricePerShare() external whenNotPaused {
+        _onlyAuthorizedActors();
+        emit FullPricePerShareUpdated(getPricePerFullShare(), now, block.number);
+    }
+
+    function pause() external {
+        _onlyAuthorizedPausers();
+        _pause();
+    }
+
+    function unpause() external {
+        _onlyGovernance();
+        _unpause();
+    }
+
+    /// ===== Internal Implementations =====
+
+    /// @dev Calculate the number of shares to issue for a given deposit
+    /// @dev This is based on the realized value of underlying assets between Sett & associated Strategy
+    function _deposit(uint256 _amount) internal {
+        uint256 _pool = balance();
+        uint256 _before = token.balanceOf(address(this));
+        token.safeTransferFrom(msg.sender, address(this), _amount);
+        uint256 _after = token.balanceOf(address(this));
+        _amount = _after.sub(_before); // Additional check for deflationary tokens
+        uint256 shares = 0;
+        if (totalSupply() == 0) {
+            shares = _amount;
+        } else {
+            shares = (_amount.mul(totalSupply())).div(_pool);
+        }
+        _mint(msg.sender, shares);
+    }
+
+    // No rebalance implementation for lower fees and faster swaps
+    function _withdraw(uint256 _shares) internal {
+        uint256 r = (balance().mul(_shares)).div(totalSupply());
+        _burn(msg.sender, _shares);
+
+        // Check balance
+        uint256 b = token.balanceOf(address(this));
+        if (b < r) {
+            uint256 _toWithdraw = r.sub(b);
+            IController(controller).withdraw(address(token), _toWithdraw);
+            uint256 _after = token.balanceOf(address(this));
+            uint256 _diff = _after.sub(b);
+            if (_diff < _toWithdraw) {
+                r = b.add(_diff);
+            }
+        }
+
+        token.safeTransfer(msg.sender, r);
+    }
+
+    function _lockForBlock(address account) internal {
+        blockLock[account] = block.number;
+    }
+
+    /// ===== ERC20 Overrides =====
+
+    /// @dev Add blockLock to transfers, users cannot transfer tokens in the same block as a deposit or withdrawal.
+    function transfer(address recipient, uint256 amount) public virtual override returns (bool) {
+        _blockLocked();
+        return super.transfer(recipient, amount);
+    }
+
+    function transferFrom(
+        address sender,
+        address recipient,
+        uint256 amount
+    ) public virtual override returns (bool) {
+        _blockLocked();
+        return super.transferFrom(sender, recipient, amount);
+    }
+}

--- a/contracts/_original/SettV3_tricrypto.sol
+++ b/contracts/_original/SettV3_tricrypto.sol
@@ -1,0 +1,1598 @@
+/**
+ *Submitted for verification at Etherscan.io on 2021-06-07
+*/
+
+// Sources flattened with hardhat v2.0.5 https://hardhat.org
+
+// File deps/@openzeppelin/contracts-upgradeable/token/ERC20/IERC20Upgradeable.sol
+
+// SPDX-License-Identifier: MIT
+
+pragma solidity ^0.6.0;
+
+/**
+ * @dev Interface of the ERC20 standard as defined in the EIP.
+ */
+interface IERC20Upgradeable {
+    /**
+     * @dev Returns the amount of tokens in existence.
+     */
+    function totalSupply() external view returns (uint256);
+
+    /**
+     * @dev Returns the amount of tokens owned by `account`.
+     */
+    function balanceOf(address account) external view returns (uint256);
+
+    /**
+     * @dev Moves `amount` tokens from the caller's account to `recipient`.
+     *
+     * Returns a boolean value indicating whether the operation succeeded.
+     *
+     * Emits a {Transfer} event.
+     */
+    function transfer(address recipient, uint256 amount) external returns (bool);
+
+    /**
+     * @dev Returns the remaining number of tokens that `spender` will be
+     * allowed to spend on behalf of `owner` through {transferFrom}. This is
+     * zero by default.
+     *
+     * This value changes when {approve} or {transferFrom} are called.
+     */
+    function allowance(address owner, address spender) external view returns (uint256);
+
+    /**
+     * @dev Sets `amount` as the allowance of `spender` over the caller's tokens.
+     *
+     * Returns a boolean value indicating whether the operation succeeded.
+     *
+     * IMPORTANT: Beware that changing an allowance with this method brings the risk
+     * that someone may use both the old and the new allowance by unfortunate
+     * transaction ordering. One possible solution to mitigate this race
+     * condition is to first reduce the spender's allowance to 0 and set the
+     * desired value afterwards:
+     * https://github.com/ethereum/EIPs/issues/20#issuecomment-263524729
+     *
+     * Emits an {Approval} event.
+     */
+    function approve(address spender, uint256 amount) external returns (bool);
+
+    /**
+     * @dev Moves `amount` tokens from `sender` to `recipient` using the
+     * allowance mechanism. `amount` is then deducted from the caller's
+     * allowance.
+     *
+     * Returns a boolean value indicating whether the operation succeeded.
+     *
+     * Emits a {Transfer} event.
+     */
+    function transferFrom(address sender, address recipient, uint256 amount) external returns (bool);
+
+    /**
+     * @dev Emitted when `value` tokens are moved from one account (`from`) to
+     * another (`to`).
+     *
+     * Note that `value` may be zero.
+     */
+    event Transfer(address indexed from, address indexed to, uint256 value);
+
+    /**
+     * @dev Emitted when the allowance of a `spender` for an `owner` is set by
+     * a call to {approve}. `value` is the new allowance.
+     */
+    event Approval(address indexed owner, address indexed spender, uint256 value);
+}
+
+
+// File deps/@openzeppelin/contracts-upgradeable/math/SafeMathUpgradeable.sol
+
+
+
+pragma solidity ^0.6.0;
+
+/**
+ * @dev Wrappers over Solidity's arithmetic operations with added overflow
+ * checks.
+ *
+ * Arithmetic operations in Solidity wrap on overflow. This can easily result
+ * in bugs, because programmers usually assume that an overflow raises an
+ * error, which is the standard behavior in high level programming languages.
+ * `SafeMath` restores this intuition by reverting the transaction when an
+ * operation overflows.
+ *
+ * Using this library instead of the unchecked operations eliminates an entire
+ * class of bugs, so it's recommended to use it always.
+ */
+library SafeMathUpgradeable {
+    /**
+     * @dev Returns the addition of two unsigned integers, reverting on
+     * overflow.
+     *
+     * Counterpart to Solidity's `+` operator.
+     *
+     * Requirements:
+     *
+     * - Addition cannot overflow.
+     */
+    function add(uint256 a, uint256 b) internal pure returns (uint256) {
+        uint256 c = a + b;
+        require(c >= a, "SafeMath: addition overflow");
+
+        return c;
+    }
+
+    /**
+     * @dev Returns the subtraction of two unsigned integers, reverting on
+     * overflow (when the result is negative).
+     *
+     * Counterpart to Solidity's `-` operator.
+     *
+     * Requirements:
+     *
+     * - Subtraction cannot overflow.
+     */
+    function sub(uint256 a, uint256 b) internal pure returns (uint256) {
+        return sub(a, b, "SafeMath: subtraction overflow");
+    }
+
+    /**
+     * @dev Returns the subtraction of two unsigned integers, reverting with custom message on
+     * overflow (when the result is negative).
+     *
+     * Counterpart to Solidity's `-` operator.
+     *
+     * Requirements:
+     *
+     * - Subtraction cannot overflow.
+     */
+    function sub(uint256 a, uint256 b, string memory errorMessage) internal pure returns (uint256) {
+        require(b <= a, errorMessage);
+        uint256 c = a - b;
+
+        return c;
+    }
+
+    /**
+     * @dev Returns the multiplication of two unsigned integers, reverting on
+     * overflow.
+     *
+     * Counterpart to Solidity's `*` operator.
+     *
+     * Requirements:
+     *
+     * - Multiplication cannot overflow.
+     */
+    function mul(uint256 a, uint256 b) internal pure returns (uint256) {
+        // Gas optimization: this is cheaper than requiring 'a' not being zero, but the
+        // benefit is lost if 'b' is also tested.
+        // See: https://github.com/OpenZeppelin/openzeppelin-contracts/pull/522
+        if (a == 0) {
+            return 0;
+        }
+
+        uint256 c = a * b;
+        require(c / a == b, "SafeMath: multiplication overflow");
+
+        return c;
+    }
+
+    /**
+     * @dev Returns the integer division of two unsigned integers. Reverts on
+     * division by zero. The result is rounded towards zero.
+     *
+     * Counterpart to Solidity's `/` operator. Note: this function uses a
+     * `revert` opcode (which leaves remaining gas untouched) while Solidity
+     * uses an invalid opcode to revert (consuming all remaining gas).
+     *
+     * Requirements:
+     *
+     * - The divisor cannot be zero.
+     */
+    function div(uint256 a, uint256 b) internal pure returns (uint256) {
+        return div(a, b, "SafeMath: division by zero");
+    }
+
+    /**
+     * @dev Returns the integer division of two unsigned integers. Reverts with custom message on
+     * division by zero. The result is rounded towards zero.
+     *
+     * Counterpart to Solidity's `/` operator. Note: this function uses a
+     * `revert` opcode (which leaves remaining gas untouched) while Solidity
+     * uses an invalid opcode to revert (consuming all remaining gas).
+     *
+     * Requirements:
+     *
+     * - The divisor cannot be zero.
+     */
+    function div(uint256 a, uint256 b, string memory errorMessage) internal pure returns (uint256) {
+        require(b > 0, errorMessage);
+        uint256 c = a / b;
+        // assert(a == b * c + a % b); // There is no case in which this doesn't hold
+
+        return c;
+    }
+
+    /**
+     * @dev Returns the remainder of dividing two unsigned integers. (unsigned integer modulo),
+     * Reverts when dividing by zero.
+     *
+     * Counterpart to Solidity's `%` operator. This function uses a `revert`
+     * opcode (which leaves remaining gas untouched) while Solidity uses an
+     * invalid opcode to revert (consuming all remaining gas).
+     *
+     * Requirements:
+     *
+     * - The divisor cannot be zero.
+     */
+    function mod(uint256 a, uint256 b) internal pure returns (uint256) {
+        return mod(a, b, "SafeMath: modulo by zero");
+    }
+
+    /**
+     * @dev Returns the remainder of dividing two unsigned integers. (unsigned integer modulo),
+     * Reverts with custom message when dividing by zero.
+     *
+     * Counterpart to Solidity's `%` operator. This function uses a `revert`
+     * opcode (which leaves remaining gas untouched) while Solidity uses an
+     * invalid opcode to revert (consuming all remaining gas).
+     *
+     * Requirements:
+     *
+     * - The divisor cannot be zero.
+     */
+    function mod(uint256 a, uint256 b, string memory errorMessage) internal pure returns (uint256) {
+        require(b != 0, errorMessage);
+        return a % b;
+    }
+}
+
+
+// File deps/@openzeppelin/contracts-upgradeable/utils/AddressUpgradeable.sol
+
+
+
+pragma solidity ^0.6.2;
+
+/**
+ * @dev Collection of functions related to the address type
+ */
+library AddressUpgradeable {
+    /**
+     * @dev Returns true if `account` is a contract.
+     *
+     * [IMPORTANT]
+     * ====
+     * It is unsafe to assume that an address for which this function returns
+     * false is an externally-owned account (EOA) and not a contract.
+     *
+     * Among others, `isContract` will return false for the following
+     * types of addresses:
+     *
+     *  - an externally-owned account
+     *  - a contract in construction
+     *  - an address where a contract will be created
+     *  - an address where a contract lived, but was destroyed
+     * ====
+     */
+    function isContract(address account) internal view returns (bool) {
+        // This method relies in extcodesize, which returns 0 for contracts in
+        // construction, since the code is only stored at the end of the
+        // constructor execution.
+
+        uint256 size;
+        // solhint-disable-next-line no-inline-assembly
+        assembly { size := extcodesize(account) }
+        return size > 0;
+    }
+
+    /**
+     * @dev Replacement for Solidity's `transfer`: sends `amount` wei to
+     * `recipient`, forwarding all available gas and reverting on errors.
+     *
+     * https://eips.ethereum.org/EIPS/eip-1884[EIP1884] increases the gas cost
+     * of certain opcodes, possibly making contracts go over the 2300 gas limit
+     * imposed by `transfer`, making them unable to receive funds via
+     * `transfer`. {sendValue} removes this limitation.
+     *
+     * https://diligence.consensys.net/posts/2019/09/stop-using-soliditys-transfer-now/[Learn more].
+     *
+     * IMPORTANT: because control is transferred to `recipient`, care must be
+     * taken to not create reentrancy vulnerabilities. Consider using
+     * {ReentrancyGuard} or the
+     * https://solidity.readthedocs.io/en/v0.5.11/security-considerations.html#use-the-checks-effects-interactions-pattern[checks-effects-interactions pattern].
+     */
+    function sendValue(address payable recipient, uint256 amount) internal {
+        require(address(this).balance >= amount, "Address: insufficient balance");
+
+        // solhint-disable-next-line avoid-low-level-calls, avoid-call-value
+        (bool success, ) = recipient.call{ value: amount }("");
+        require(success, "Address: unable to send value, recipient may have reverted");
+    }
+
+    /**
+     * @dev Performs a Solidity function call using a low level `call`. A
+     * plain`call` is an unsafe replacement for a function call: use this
+     * function instead.
+     *
+     * If `target` reverts with a revert reason, it is bubbled up by this
+     * function (like regular Solidity function calls).
+     *
+     * Returns the raw returned data. To convert to the expected return value,
+     * use https://solidity.readthedocs.io/en/latest/units-and-global-variables.html?highlight=abi.decode#abi-encoding-and-decoding-functions[`abi.decode`].
+     *
+     * Requirements:
+     *
+     * - `target` must be a contract.
+     * - calling `target` with `data` must not revert.
+     *
+     * _Available since v3.1._
+     */
+    function functionCall(address target, bytes memory data) internal returns (bytes memory) {
+      return functionCall(target, data, "Address: low-level call failed");
+    }
+
+    /**
+     * @dev Same as {xref-Address-functionCall-address-bytes-}[`functionCall`], but with
+     * `errorMessage` as a fallback revert reason when `target` reverts.
+     *
+     * _Available since v3.1._
+     */
+    function functionCall(address target, bytes memory data, string memory errorMessage) internal returns (bytes memory) {
+        return _functionCallWithValue(target, data, 0, errorMessage);
+    }
+
+    /**
+     * @dev Same as {xref-Address-functionCall-address-bytes-}[`functionCall`],
+     * but also transferring `value` wei to `target`.
+     *
+     * Requirements:
+     *
+     * - the calling contract must have an ETH balance of at least `value`.
+     * - the called Solidity function must be `payable`.
+     *
+     * _Available since v3.1._
+     */
+    function functionCallWithValue(address target, bytes memory data, uint256 value) internal returns (bytes memory) {
+        return functionCallWithValue(target, data, value, "Address: low-level call with value failed");
+    }
+
+    /**
+     * @dev Same as {xref-Address-functionCallWithValue-address-bytes-uint256-}[`functionCallWithValue`], but
+     * with `errorMessage` as a fallback revert reason when `target` reverts.
+     *
+     * _Available since v3.1._
+     */
+    function functionCallWithValue(address target, bytes memory data, uint256 value, string memory errorMessage) internal returns (bytes memory) {
+        require(address(this).balance >= value, "Address: insufficient balance for call");
+        return _functionCallWithValue(target, data, value, errorMessage);
+    }
+
+    function _functionCallWithValue(address target, bytes memory data, uint256 weiValue, string memory errorMessage) private returns (bytes memory) {
+        require(isContract(target), "Address: call to non-contract");
+
+        // solhint-disable-next-line avoid-low-level-calls
+        (bool success, bytes memory returndata) = target.call{ value: weiValue }(data);
+        if (success) {
+            return returndata;
+        } else {
+            // Look for revert reason and bubble it up if present
+            if (returndata.length > 0) {
+                // The easiest way to bubble the revert reason is using memory via assembly
+
+                // solhint-disable-next-line no-inline-assembly
+                assembly {
+                    let returndata_size := mload(returndata)
+                    revert(add(32, returndata), returndata_size)
+                }
+            } else {
+                revert(errorMessage);
+            }
+        }
+    }
+}
+
+
+// File deps/@openzeppelin/contracts-upgradeable/token/ERC20/SafeERC20Upgradeable.sol
+
+
+
+pragma solidity ^0.6.0;
+
+
+
+/**
+ * @title SafeERC20
+ * @dev Wrappers around ERC20 operations that throw on failure (when the token
+ * contract returns false). Tokens that return no value (and instead revert or
+ * throw on failure) are also supported, non-reverting calls are assumed to be
+ * successful.
+ * To use this library you can add a `using SafeERC20 for IERC20;` statement to your contract,
+ * which allows you to call the safe operations as `token.safeTransfer(...)`, etc.
+ */
+library SafeERC20Upgradeable {
+    using SafeMathUpgradeable for uint256;
+    using AddressUpgradeable for address;
+
+    function safeTransfer(IERC20Upgradeable token, address to, uint256 value) internal {
+        _callOptionalReturn(token, abi.encodeWithSelector(token.transfer.selector, to, value));
+    }
+
+    function safeTransferFrom(IERC20Upgradeable token, address from, address to, uint256 value) internal {
+        _callOptionalReturn(token, abi.encodeWithSelector(token.transferFrom.selector, from, to, value));
+    }
+
+    /**
+     * @dev Deprecated. This function has issues similar to the ones found in
+     * {IERC20-approve}, and its usage is discouraged.
+     *
+     * Whenever possible, use {safeIncreaseAllowance} and
+     * {safeDecreaseAllowance} instead.
+     */
+    function safeApprove(IERC20Upgradeable token, address spender, uint256 value) internal {
+        // safeApprove should only be called when setting an initial allowance,
+        // or when resetting it to zero. To increase and decrease it, use
+        // 'safeIncreaseAllowance' and 'safeDecreaseAllowance'
+        // solhint-disable-next-line max-line-length
+        require((value == 0) || (token.allowance(address(this), spender) == 0),
+            "SafeERC20: approve from non-zero to non-zero allowance"
+        );
+        _callOptionalReturn(token, abi.encodeWithSelector(token.approve.selector, spender, value));
+    }
+
+    function safeIncreaseAllowance(IERC20Upgradeable token, address spender, uint256 value) internal {
+        uint256 newAllowance = token.allowance(address(this), spender).add(value);
+        _callOptionalReturn(token, abi.encodeWithSelector(token.approve.selector, spender, newAllowance));
+    }
+
+    function safeDecreaseAllowance(IERC20Upgradeable token, address spender, uint256 value) internal {
+        uint256 newAllowance = token.allowance(address(this), spender).sub(value, "SafeERC20: decreased allowance below zero");
+        _callOptionalReturn(token, abi.encodeWithSelector(token.approve.selector, spender, newAllowance));
+    }
+
+    /**
+     * @dev Imitates a Solidity high-level call (i.e. a regular function call to a contract), relaxing the requirement
+     * on the return value: the return value is optional (but if data is returned, it must not be false).
+     * @param token The token targeted by the call.
+     * @param data The call data (encoded using abi.encode or one of its variants).
+     */
+    function _callOptionalReturn(IERC20Upgradeable token, bytes memory data) private {
+        // We need to perform a low level call here, to bypass Solidity's return data size checking mechanism, since
+        // we're implementing it ourselves. We use {Address.functionCall} to perform this call, which verifies that
+        // the target address contains contract code and also asserts for success in the low-level call.
+
+        bytes memory returndata = address(token).functionCall(data, "SafeERC20: low-level call failed");
+        if (returndata.length > 0) { // Return data is optional
+            // solhint-disable-next-line max-line-length
+            require(abi.decode(returndata, (bool)), "SafeERC20: ERC20 operation did not succeed");
+        }
+    }
+}
+
+
+// File deps/@openzeppelin/contracts-upgradeable/proxy/Initializable.sol
+
+
+
+pragma solidity >=0.4.24 <0.7.0;
+
+
+/**
+ * @dev This is a base contract to aid in writing upgradeable contracts, or any kind of contract that will be deployed
+ * behind a proxy. Since a proxied contract can't have a constructor, it's common to move constructor logic to an
+ * external initializer function, usually called `initialize`. It then becomes necessary to protect this initializer
+ * function so it can only be called once. The {initializer} modifier provided by this contract will have this effect.
+ * 
+ * TIP: To avoid leaving the proxy in an uninitialized state, the initializer function should be called as early as
+ * possible by providing the encoded function call as the `_data` argument to {UpgradeableProxy-constructor}.
+ * 
+ * CAUTION: When used with inheritance, manual care must be taken to not invoke a parent initializer twice, or to ensure
+ * that all initializers are idempotent. This is not verified automatically as constructors are by Solidity.
+ */
+abstract contract Initializable {
+
+    /**
+     * @dev Indicates that the contract has been initialized.
+     */
+    bool private _initialized;
+
+    /**
+     * @dev Indicates that the contract is in the process of being initialized.
+     */
+    bool private _initializing;
+
+    /**
+     * @dev Modifier to protect an initializer function from being invoked twice.
+     */
+    modifier initializer() {
+        require(_initializing || _isConstructor() || !_initialized, "Initializable: contract is already initialized");
+
+        bool isTopLevelCall = !_initializing;
+        if (isTopLevelCall) {
+            _initializing = true;
+            _initialized = true;
+        }
+
+        _;
+
+        if (isTopLevelCall) {
+            _initializing = false;
+        }
+    }
+
+    /// @dev Returns true if and only if the function is running in the constructor
+    function _isConstructor() private view returns (bool) {
+        // extcodesize checks the size of the code stored in an address, and
+        // address returns the current address. Since the code is still not
+        // deployed when running a constructor, any checks on its code size will
+        // yield zero, making it an effective way to detect if a contract is
+        // under construction or not.
+        address self = address(this);
+        uint256 cs;
+        // solhint-disable-next-line no-inline-assembly
+        assembly { cs := extcodesize(self) }
+        return cs == 0;
+    }
+}
+
+
+// File deps/@openzeppelin/contracts-upgradeable/GSN/ContextUpgradeable.sol
+
+
+
+pragma solidity ^0.6.0;
+
+/*
+ * @dev Provides information about the current execution context, including the
+ * sender of the transaction and its data. While these are generally available
+ * via msg.sender and msg.data, they should not be accessed in such a direct
+ * manner, since when dealing with GSN meta-transactions the account sending and
+ * paying for execution may not be the actual sender (as far as an application
+ * is concerned).
+ *
+ * This contract is only required for intermediate, library-like contracts.
+ */
+abstract contract ContextUpgradeable is Initializable {
+    function __Context_init() internal initializer {
+        __Context_init_unchained();
+    }
+
+    function __Context_init_unchained() internal initializer {
+    }
+    function _msgSender() internal view virtual returns (address payable) {
+        return msg.sender;
+    }
+
+    function _msgData() internal view virtual returns (bytes memory) {
+        this; // silence state mutability warning without generating bytecode - see https://github.com/ethereum/solidity/issues/2691
+        return msg.data;
+    }
+    uint256[50] private __gap;
+}
+
+
+// File deps/@openzeppelin/contracts-upgradeable/token/ERC20/ERC20Upgradeable.sol
+
+
+
+pragma solidity ^0.6.0;
+
+
+
+
+
+/**
+ * @dev Implementation of the {IERC20} interface.
+ *
+ * This implementation is agnostic to the way tokens are created. This means
+ * that a supply mechanism has to be added in a derived contract using {_mint}.
+ * For a generic mechanism see {ERC20PresetMinterPauser}.
+ *
+ * TIP: For a detailed writeup see our guide
+ * https://forum.zeppelin.solutions/t/how-to-implement-erc20-supply-mechanisms/226[How
+ * to implement supply mechanisms].
+ *
+ * We have followed general OpenZeppelin guidelines: functions revert instead
+ * of returning `false` on failure. This behavior is nonetheless conventional
+ * and does not conflict with the expectations of ERC20 applications.
+ *
+ * Additionally, an {Approval} event is emitted on calls to {transferFrom}.
+ * This allows applications to reconstruct the allowance for all accounts just
+ * by listening to said events. Other implementations of the EIP may not emit
+ * these events, as it isn't required by the specification.
+ *
+ * Finally, the non-standard {decreaseAllowance} and {increaseAllowance}
+ * functions have been added to mitigate the well-known issues around setting
+ * allowances. See {IERC20-approve}.
+ */
+contract ERC20Upgradeable is Initializable, ContextUpgradeable, IERC20Upgradeable {
+    using SafeMathUpgradeable for uint256;
+    using AddressUpgradeable for address;
+
+    mapping (address => uint256) private _balances;
+
+    mapping (address => mapping (address => uint256)) private _allowances;
+
+    uint256 private _totalSupply;
+
+    string private _name;
+    string private _symbol;
+    uint8 private _decimals;
+
+    /**
+     * @dev Sets the values for {name} and {symbol}, initializes {decimals} with
+     * a default value of 18.
+     *
+     * To select a different value for {decimals}, use {_setupDecimals}.
+     *
+     * All three of these values are immutable: they can only be set once during
+     * construction.
+     */
+    function __ERC20_init(string memory name, string memory symbol) internal initializer {
+        __Context_init_unchained();
+        __ERC20_init_unchained(name, symbol);
+    }
+
+    function __ERC20_init_unchained(string memory name, string memory symbol) internal initializer {
+        _name = name;
+        _symbol = symbol;
+        _decimals = 18;
+    }
+
+    /**
+     * @dev Returns the name of the token.
+     */
+    function name() public view returns (string memory) {
+        return _name;
+    }
+
+    /**
+     * @dev Returns the symbol of the token, usually a shorter version of the
+     * name.
+     */
+    function symbol() public view returns (string memory) {
+        return _symbol;
+    }
+
+    /**
+     * @dev Returns the number of decimals used to get its user representation.
+     * For example, if `decimals` equals `2`, a balance of `505` tokens should
+     * be displayed to a user as `5,05` (`505 / 10 ** 2`).
+     *
+     * Tokens usually opt for a value of 18, imitating the relationship between
+     * Ether and Wei. This is the value {ERC20} uses, unless {_setupDecimals} is
+     * called.
+     *
+     * NOTE: This information is only used for _display_ purposes: it in
+     * no way affects any of the arithmetic of the contract, including
+     * {IERC20-balanceOf} and {IERC20-transfer}.
+     */
+    function decimals() public view returns (uint8) {
+        return _decimals;
+    }
+
+    /**
+     * @dev See {IERC20-totalSupply}.
+     */
+    function totalSupply() public view override returns (uint256) {
+        return _totalSupply;
+    }
+
+    /**
+     * @dev See {IERC20-balanceOf}.
+     */
+    function balanceOf(address account) public view override returns (uint256) {
+        return _balances[account];
+    }
+
+    /**
+     * @dev See {IERC20-transfer}.
+     *
+     * Requirements:
+     *
+     * - `recipient` cannot be the zero address.
+     * - the caller must have a balance of at least `amount`.
+     */
+    function transfer(address recipient, uint256 amount) public virtual override returns (bool) {
+        _transfer(_msgSender(), recipient, amount);
+        return true;
+    }
+
+    /**
+     * @dev See {IERC20-allowance}.
+     */
+    function allowance(address owner, address spender) public view virtual override returns (uint256) {
+        return _allowances[owner][spender];
+    }
+
+    /**
+     * @dev See {IERC20-approve}.
+     *
+     * Requirements:
+     *
+     * - `spender` cannot be the zero address.
+     */
+    function approve(address spender, uint256 amount) public virtual override returns (bool) {
+        _approve(_msgSender(), spender, amount);
+        return true;
+    }
+
+    /**
+     * @dev See {IERC20-transferFrom}.
+     *
+     * Emits an {Approval} event indicating the updated allowance. This is not
+     * required by the EIP. See the note at the beginning of {ERC20};
+     *
+     * Requirements:
+     * - `sender` and `recipient` cannot be the zero address.
+     * - `sender` must have a balance of at least `amount`.
+     * - the caller must have allowance for ``sender``'s tokens of at least
+     * `amount`.
+     */
+    function transferFrom(address sender, address recipient, uint256 amount) public virtual override returns (bool) {
+        _transfer(sender, recipient, amount);
+        _approve(sender, _msgSender(), _allowances[sender][_msgSender()].sub(amount, "ERC20: transfer amount exceeds allowance"));
+        return true;
+    }
+
+    /**
+     * @dev Atomically increases the allowance granted to `spender` by the caller.
+     *
+     * This is an alternative to {approve} that can be used as a mitigation for
+     * problems described in {IERC20-approve}.
+     *
+     * Emits an {Approval} event indicating the updated allowance.
+     *
+     * Requirements:
+     *
+     * - `spender` cannot be the zero address.
+     */
+    function increaseAllowance(address spender, uint256 addedValue) public virtual returns (bool) {
+        _approve(_msgSender(), spender, _allowances[_msgSender()][spender].add(addedValue));
+        return true;
+    }
+
+    /**
+     * @dev Atomically decreases the allowance granted to `spender` by the caller.
+     *
+     * This is an alternative to {approve} that can be used as a mitigation for
+     * problems described in {IERC20-approve}.
+     *
+     * Emits an {Approval} event indicating the updated allowance.
+     *
+     * Requirements:
+     *
+     * - `spender` cannot be the zero address.
+     * - `spender` must have allowance for the caller of at least
+     * `subtractedValue`.
+     */
+    function decreaseAllowance(address spender, uint256 subtractedValue) public virtual returns (bool) {
+        _approve(_msgSender(), spender, _allowances[_msgSender()][spender].sub(subtractedValue, "ERC20: decreased allowance below zero"));
+        return true;
+    }
+
+    /**
+     * @dev Moves tokens `amount` from `sender` to `recipient`.
+     *
+     * This is internal function is equivalent to {transfer}, and can be used to
+     * e.g. implement automatic token fees, slashing mechanisms, etc.
+     *
+     * Emits a {Transfer} event.
+     *
+     * Requirements:
+     *
+     * - `sender` cannot be the zero address.
+     * - `recipient` cannot be the zero address.
+     * - `sender` must have a balance of at least `amount`.
+     */
+    function _transfer(address sender, address recipient, uint256 amount) internal virtual {
+        require(sender != address(0), "ERC20: transfer from the zero address");
+        require(recipient != address(0), "ERC20: transfer to the zero address");
+
+        _beforeTokenTransfer(sender, recipient, amount);
+
+        _balances[sender] = _balances[sender].sub(amount, "ERC20: transfer amount exceeds balance");
+        _balances[recipient] = _balances[recipient].add(amount);
+        emit Transfer(sender, recipient, amount);
+    }
+
+    /** @dev Creates `amount` tokens and assigns them to `account`, increasing
+     * the total supply.
+     *
+     * Emits a {Transfer} event with `from` set to the zero address.
+     *
+     * Requirements
+     *
+     * - `to` cannot be the zero address.
+     */
+    function _mint(address account, uint256 amount) internal virtual {
+        require(account != address(0), "ERC20: mint to the zero address");
+
+        _beforeTokenTransfer(address(0), account, amount);
+
+        _totalSupply = _totalSupply.add(amount);
+        _balances[account] = _balances[account].add(amount);
+        emit Transfer(address(0), account, amount);
+    }
+
+    /**
+     * @dev Destroys `amount` tokens from `account`, reducing the
+     * total supply.
+     *
+     * Emits a {Transfer} event with `to` set to the zero address.
+     *
+     * Requirements
+     *
+     * - `account` cannot be the zero address.
+     * - `account` must have at least `amount` tokens.
+     */
+    function _burn(address account, uint256 amount) internal virtual {
+        require(account != address(0), "ERC20: burn from the zero address");
+
+        _beforeTokenTransfer(account, address(0), amount);
+
+        _balances[account] = _balances[account].sub(amount, "ERC20: burn amount exceeds balance");
+        _totalSupply = _totalSupply.sub(amount);
+        emit Transfer(account, address(0), amount);
+    }
+
+    /**
+     * @dev Sets `amount` as the allowance of `spender` over the `owner` s tokens.
+     *
+     * This internal function is equivalent to `approve`, and can be used to
+     * e.g. set automatic allowances for certain subsystems, etc.
+     *
+     * Emits an {Approval} event.
+     *
+     * Requirements:
+     *
+     * - `owner` cannot be the zero address.
+     * - `spender` cannot be the zero address.
+     */
+    function _approve(address owner, address spender, uint256 amount) internal virtual {
+        require(owner != address(0), "ERC20: approve from the zero address");
+        require(spender != address(0), "ERC20: approve to the zero address");
+
+        _allowances[owner][spender] = amount;
+        emit Approval(owner, spender, amount);
+    }
+
+    /**
+     * @dev Sets {decimals} to a value other than the default one of 18.
+     *
+     * WARNING: This function should only be called from the constructor. Most
+     * applications that interact with token contracts will not expect
+     * {decimals} to ever change, and may work incorrectly if it does.
+     */
+    function _setupDecimals(uint8 decimals_) internal {
+        _decimals = decimals_;
+    }
+
+    /**
+     * @dev Hook that is called before any transfer of tokens. This includes
+     * minting and burning.
+     *
+     * Calling conditions:
+     *
+     * - when `from` and `to` are both non-zero, `amount` of ``from``'s tokens
+     * will be to transferred to `to`.
+     * - when `from` is zero, `amount` tokens will be minted for `to`.
+     * - when `to` is zero, `amount` of ``from``'s tokens will be burned.
+     * - `from` and `to` are never both zero.
+     *
+     * To learn more about hooks, head to xref:ROOT:extending-contracts.adoc#using-hooks[Using Hooks].
+     */
+    function _beforeTokenTransfer(address from, address to, uint256 amount) internal virtual { }
+    uint256[44] private __gap;
+}
+
+
+// File deps/@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol
+
+
+
+pragma solidity ^0.6.0;
+
+
+/**
+ * @dev Contract module which provides a basic access control mechanism, where
+ * there is an account (an owner) that can be granted exclusive access to
+ * specific functions.
+ *
+ * By default, the owner account will be the one that deploys the contract. This
+ * can later be changed with {transferOwnership}.
+ *
+ * This module is used through inheritance. It will make available the modifier
+ * `onlyOwner`, which can be applied to your functions to restrict their use to
+ * the owner.
+ */
+contract OwnableUpgradeable is Initializable, ContextUpgradeable {
+    address private _owner;
+
+    event OwnershipTransferred(address indexed previousOwner, address indexed newOwner);
+
+    /**
+     * @dev Initializes the contract setting the deployer as the initial owner.
+     */
+    function __Ownable_init() internal initializer {
+        __Context_init_unchained();
+        __Ownable_init_unchained();
+    }
+
+    function __Ownable_init_unchained() internal initializer {
+        address msgSender = _msgSender();
+        _owner = msgSender;
+        emit OwnershipTransferred(address(0), msgSender);
+    }
+
+    /**
+     * @dev Returns the address of the current owner.
+     */
+    function owner() public view returns (address) {
+        return _owner;
+    }
+
+    /**
+     * @dev Throws if called by any account other than the owner.
+     */
+    modifier onlyOwner() {
+        require(_owner == _msgSender(), "Ownable: caller is not the owner");
+        _;
+    }
+
+    /**
+     * @dev Leaves the contract without owner. It will not be possible to call
+     * `onlyOwner` functions anymore. Can only be called by the current owner.
+     *
+     * NOTE: Renouncing ownership will leave the contract without an owner,
+     * thereby removing any functionality that is only available to the owner.
+     */
+    function renounceOwnership() public virtual onlyOwner {
+        emit OwnershipTransferred(_owner, address(0));
+        _owner = address(0);
+    }
+
+    /**
+     * @dev Transfers ownership of the contract to a new account (`newOwner`).
+     * Can only be called by the current owner.
+     */
+    function transferOwnership(address newOwner) public virtual onlyOwner {
+        require(newOwner != address(0), "Ownable: new owner is the zero address");
+        emit OwnershipTransferred(_owner, newOwner);
+        _owner = newOwner;
+    }
+    uint256[49] private __gap;
+}
+
+
+// File deps/@openzeppelin/contracts-upgradeable/utils/PausableUpgradeable.sol
+
+
+
+pragma solidity ^0.6.0;
+
+
+/**
+ * @dev Contract module which allows children to implement an emergency stop
+ * mechanism that can be triggered by an authorized account.
+ *
+ * This module is used through inheritance. It will make available the
+ * modifiers `whenNotPaused` and `whenPaused`, which can be applied to
+ * the functions of your contract. Note that they will not be pausable by
+ * simply including this module, only once the modifiers are put in place.
+ */
+contract PausableUpgradeable is Initializable, ContextUpgradeable {
+    /**
+     * @dev Emitted when the pause is triggered by `account`.
+     */
+    event Paused(address account);
+
+    /**
+     * @dev Emitted when the pause is lifted by `account`.
+     */
+    event Unpaused(address account);
+
+    bool private _paused;
+
+    /**
+     * @dev Initializes the contract in unpaused state.
+     */
+    function __Pausable_init() internal initializer {
+        __Context_init_unchained();
+        __Pausable_init_unchained();
+    }
+
+    function __Pausable_init_unchained() internal initializer {
+        _paused = false;
+    }
+
+    /**
+     * @dev Returns true if the contract is paused, and false otherwise.
+     */
+    function paused() public view returns (bool) {
+        return _paused;
+    }
+
+    /**
+     * @dev Modifier to make a function callable only when the contract is not paused.
+     *
+     * Requirements:
+     *
+     * - The contract must not be paused.
+     */
+    modifier whenNotPaused() {
+        require(!_paused, "Pausable: paused");
+        _;
+    }
+
+    /**
+     * @dev Modifier to make a function callable only when the contract is paused.
+     *
+     * Requirements:
+     *
+     * - The contract must be paused.
+     */
+    modifier whenPaused() {
+        require(_paused, "Pausable: not paused");
+        _;
+    }
+
+    /**
+     * @dev Triggers stopped state.
+     *
+     * Requirements:
+     *
+     * - The contract must not be paused.
+     */
+    function _pause() internal virtual whenNotPaused {
+        _paused = true;
+        emit Paused(_msgSender());
+    }
+
+    /**
+     * @dev Returns to normal state.
+     *
+     * Requirements:
+     *
+     * - The contract must be paused.
+     */
+    function _unpause() internal virtual whenPaused {
+        _paused = false;
+        emit Unpaused(_msgSender());
+    }
+    uint256[49] private __gap;
+}
+
+
+// File interfaces/badger/IController.sol
+
+
+pragma solidity >=0.5.0 <0.8.0;
+
+interface IController {
+    function withdraw(address, uint256) external;
+
+    function strategies(address) external view returns (address);
+
+    function balanceOf(address) external view returns (uint256);
+
+    function earn(address, uint256) external;
+
+    function want(address) external view returns (address);
+
+    function rewards() external view returns (address);
+
+    function vaults(address) external view returns (address);
+}
+
+
+// File interfaces/erc20/IERC20Detailed.sol
+
+
+
+pragma solidity ^0.6.0;
+
+/**
+ * @dev Interface of the ERC20 standard as defined in the EIP.
+ */
+interface IERC20Detailed {
+    /**
+     * @dev Returns the amount of tokens in existence.
+     */
+    function totalSupply() external view returns (uint256);
+
+    function name() external view returns (string memory);
+    function symbol() external view returns (string memory);
+
+    /**
+     * @dev Returns the amount of tokens owned by `account`.
+     */
+    function balanceOf(address account) external view returns (uint256);
+
+    /**
+     * @dev Moves `amount` tokens from the caller's account to `recipient`.
+     *
+     * Returns a boolean value indicating whether the operation succeeded.
+     *
+     * Emits a {Transfer} event.
+     */
+    function transfer(address recipient, uint256 amount) external returns (bool);
+
+    /**
+     * @dev Returns the remaining number of tokens that `spender` will be
+     * allowed to spend on behalf of `owner` through {transferFrom}. This is
+     * zero by default.
+     *
+     * This value changes when {approve} or {transferFrom} are called.
+     */
+    function allowance(address owner, address spender) external view returns (uint256);
+
+    /**
+     * @dev Sets `amount` as the allowance of `spender` over the caller's tokens.
+     *
+     * Returns a boolean value indicating whether the operation succeeded.
+     *
+     * IMPORTANT: Beware that changing an allowance with this method brings the risk
+     * that someone may use both the old and the new allowance by unfortunate
+     * transaction ordering. One possible solution to mitigate this race
+     * condition is to first reduce the spender's allowance to 0 and set the
+     * desired value afterwards:
+     * https://github.com/ethereum/EIPs/issues/20#issuecomment-263524729
+     *
+     * Emits an {Approval} event.
+     */
+    function approve(address spender, uint256 amount) external returns (bool);
+
+    /**
+     * @dev Moves `amount` tokens from `sender` to `recipient` using the
+     * allowance mechanism. `amount` is then deducted from the caller's
+     * allowance.
+     *
+     * Returns a boolean value indicating whether the operation succeeded.
+     *
+     * Emits a {Transfer} event.
+     */
+    function transferFrom(address sender, address recipient, uint256 amount) external returns (bool);
+
+    /**
+     * @dev Emitted when `value` tokens are moved from one account (`from`) to
+     * another (`to`).
+     *
+     * Note that `value` may be zero.
+     */
+    event Transfer(address indexed from, address indexed to, uint256 value);
+
+    /**
+     * @dev Emitted when the allowance of a `spender` for an `owner` is set by
+     * a call to {approve}. `value` is the new allowance.
+     */
+    event Approval(address indexed owner, address indexed spender, uint256 value);
+}
+
+
+// File contracts/badger-sett/SettAccessControl.sol
+
+
+pragma solidity ^0.6.11;
+
+/*
+    Common base for permissioned roles throughout Sett ecosystem
+*/
+contract SettAccessControl is Initializable {
+    address public governance;
+    address public strategist;
+    address public keeper;
+
+    // ===== MODIFIERS =====
+    function _onlyGovernance() internal view {
+        require(msg.sender == governance, "onlyGovernance");
+    }
+
+    function _onlyGovernanceOrStrategist() internal view {
+        require(msg.sender == strategist || msg.sender == governance, "onlyGovernanceOrStrategist");
+    }
+
+    function _onlyAuthorizedActors() internal view {
+        require(msg.sender == keeper || msg.sender == governance, "onlyAuthorizedActors");
+    }
+
+    // ===== PERMISSIONED ACTIONS =====
+
+    /// @notice Change strategist address
+    /// @notice Can only be changed by governance itself
+    function setStrategist(address _strategist) external {
+        _onlyGovernance();
+        strategist = _strategist;
+    }
+
+    /// @notice Change keeper address
+    /// @notice Can only be changed by governance itself
+    function setKeeper(address _keeper) external {
+        _onlyGovernance();
+        keeper = _keeper;
+    }
+
+    /// @notice Change governance address
+    /// @notice Can only be changed by governance itself
+    function setGovernance(address _governance) public {
+        _onlyGovernance();
+        governance = _governance;
+    }
+
+    uint256[50] private __gap;
+}
+
+
+// File contracts/badger-sett/SettAccessControlDefended.sol
+
+
+pragma solidity ^0.6.11;
+
+/*
+    Add ability to prevent unwanted contract access to Sett permissions
+*/
+contract SettAccessControlDefended is SettAccessControl {
+    mapping (address => bool) public approved;
+
+    function approveContractAccess(address account) external {
+        _onlyGovernance();
+        approved[account] = true;
+    }
+
+    function revokeContractAccess(address account) external {
+        _onlyGovernance();
+        approved[account] = false;
+    }
+
+    function _defend() internal view returns (bool) {
+        require(approved[msg.sender] || msg.sender == tx.origin, "Access denied for caller");
+    }
+    uint256[50] private __gap;
+}
+
+
+// File interfaces/yearn/BadgerGuestlistApi.sol
+
+
+pragma solidity >=0.6.0 <0.7.0;
+
+interface BadgerGuestListAPI {
+    function authorized(address guest, uint256 amount, bytes32[] calldata merkleProof) external view returns (bool);
+    function setGuests(address[] calldata _guests, bool[] calldata _invited) external;
+}
+
+
+// File contracts/badger-sett/SettV3.sol
+
+
+
+pragma solidity ^0.6.11;
+
+
+
+
+
+
+
+
+
+
+/* 
+    Source: https://github.com/iearn-finance/yearn-protocol/blob/develop/contracts/vaults/yVault.sol
+    
+    Changelog:
+
+    V1.1
+    * Strategist no longer has special function calling permissions
+    * Version function added to contract
+    * All write functions, with the exception of transfer, are pausable
+    * Keeper or governance can pause
+    * Only governance can unpause
+
+    V1.2
+    * Transfer functions are now pausable along with all other non-permissioned write functions
+    * All permissioned write functions, with the exception of pause() & unpause(), are pausable as well
+
+    V1.3
+    * Add guest list functionality
+    * All deposits can be optionally gated by external guestList approval logic on set guestList contract
+*/
+
+contract SettV3 is ERC20Upgradeable, SettAccessControlDefended, PausableUpgradeable {
+    using SafeERC20Upgradeable for IERC20Upgradeable;
+    using AddressUpgradeable for address;
+    using SafeMathUpgradeable for uint256;
+
+    IERC20Upgradeable public token;
+
+    uint256 public min;
+    uint256 public constant max = 10000;
+
+    address public controller;
+
+    mapping(address => uint256) public blockLock;
+
+    string internal constant _defaultNamePrefix = "Badger Sett ";
+    string internal constant _symbolSymbolPrefix = "b";
+
+    address public guardian;
+
+    BadgerGuestListAPI public guestList;
+
+    event FullPricePerShareUpdated(uint256 value, uint256 indexed timestamp, uint256 indexed blockNumber);
+
+    function initialize(
+        address _token,
+        address _controller,
+        address _governance,
+        address _keeper,
+        address _guardian,
+        bool _overrideTokenName,
+        string memory _namePrefix,
+        string memory _symbolPrefix
+    ) public initializer whenNotPaused {
+        IERC20Detailed namedToken = IERC20Detailed(_token);
+        string memory tokenName = namedToken.name();
+        string memory tokenSymbol = namedToken.symbol();
+
+        string memory name;
+        string memory symbol;
+
+        if (_overrideTokenName) {
+            name = string(abi.encodePacked(_namePrefix, tokenName));
+            symbol = string(abi.encodePacked(_symbolPrefix, tokenSymbol));
+        } else {
+            name = string(abi.encodePacked(_defaultNamePrefix, tokenName));
+            symbol = string(abi.encodePacked(_symbolSymbolPrefix, tokenSymbol));
+        }
+
+        __ERC20_init(name, symbol);
+
+        token = IERC20Upgradeable(_token);
+        governance = _governance;
+        strategist = address(0);
+        keeper = _keeper;
+        controller = _controller;
+        guardian = _guardian;
+
+        min = 9500;
+
+        emit FullPricePerShareUpdated(getPricePerFullShare(), now, block.number);
+
+        // Paused on launch
+        _pause();
+    }
+
+    /// ===== Modifiers =====
+
+    function _onlyController() internal view {
+        require(msg.sender == controller, "onlyController");
+    }
+
+    function _onlyAuthorizedPausers() internal view {
+        require(msg.sender == guardian || msg.sender == governance, "onlyPausers");
+    }
+
+    function _blockLocked() internal view {
+        require(blockLock[msg.sender] < block.number, "blockLocked");
+    }
+
+    /// ===== View Functions =====
+
+    function version() public view returns (string memory) {
+        return "1.3";
+    }
+
+    function getPricePerFullShare() public view virtual returns (uint256) {
+        if (totalSupply() == 0) {
+            return 1e18;
+        }
+        return balance().mul(1e18).div(totalSupply());
+    }
+
+    /// @notice Return the total balance of the underlying token within the system
+    /// @notice Sums the balance in the Sett, the Controller, and the Strategy
+    function balance() public view virtual returns (uint256) {
+        return token.balanceOf(address(this)).add(IController(controller).balanceOf(address(token)));
+    }
+
+    /// @notice Defines how much of the Setts' underlying can be borrowed by the Strategy for use
+    /// @notice Custom logic in here for how much the vault allows to be borrowed
+    /// @notice Sets minimum required on-hand to keep small withdrawals cheap
+    function available() public view virtual returns (uint256) {
+        return token.balanceOf(address(this)).mul(min).div(max);
+    }
+
+    /// ===== Public Actions =====
+
+    /// @notice Deposit assets into the Sett, and return corresponding shares to the user
+    /// @notice Only callable by EOA accounts that pass the _defend() check
+    function deposit(uint256 _amount) public whenNotPaused {
+        _defend();
+        _blockLocked();
+
+        _lockForBlock(msg.sender);
+        _depositWithAuthorization(_amount, new bytes32[](0));
+    }
+
+    /// @notice Deposit variant with proof for merkle guest list
+    function deposit(uint256 _amount, bytes32[] memory proof) public whenNotPaused {
+        _defend();
+        _blockLocked();
+
+        _lockForBlock(msg.sender);
+        _depositWithAuthorization(_amount, proof);
+    }
+
+    /// @notice Convenience function: Deposit entire balance of asset into the Sett, and return corresponding shares to the user
+    /// @notice Only callable by EOA accounts that pass the _defend() check
+    function depositAll() external whenNotPaused {
+        _defend();
+        _blockLocked();
+
+        _lockForBlock(msg.sender);
+        _depositWithAuthorization(token.balanceOf(msg.sender), new bytes32[](0));
+    }
+
+    /// @notice DepositAll variant with proof for merkle guest list
+    function depositAll(bytes32[] memory proof) external whenNotPaused {
+        _defend();
+        _blockLocked();
+
+        _lockForBlock(msg.sender);
+        _depositWithAuthorization(token.balanceOf(msg.sender), proof);
+    }
+
+    /// @notice No rebalance implementation for lower fees and faster swaps
+    function withdraw(uint256 _shares) public whenNotPaused {
+        _defend();
+        _blockLocked();
+
+        _lockForBlock(msg.sender);
+        _withdraw(_shares);
+    }
+
+    /// @notice Convenience function: Withdraw all shares of the sender
+    function withdrawAll() external whenNotPaused {
+        _defend();
+        _blockLocked();
+
+        _lockForBlock(msg.sender);
+        _withdraw(balanceOf(msg.sender));
+    }
+
+    /// ===== Permissioned Actions: Governance =====
+
+    function setGuestList(address _guestList) external whenNotPaused {
+        _onlyGovernance();
+        guestList = BadgerGuestListAPI(_guestList);
+    }
+
+    /// @notice Set minimum threshold of underlying that must be deposited in strategy
+    /// @notice Can only be changed by governance
+    function setMin(uint256 _min) external whenNotPaused {
+        _onlyGovernance();
+        min = _min;
+    }
+
+    /// @notice Change controller address
+    /// @notice Can only be changed by governance
+    function setController(address _controller) public whenNotPaused {
+        _onlyGovernance();
+        controller = _controller;
+    }
+
+    /// @notice Change guardian address
+    /// @notice Can only be changed by governance
+    function setGuardian(address _guardian) external whenNotPaused {
+        _onlyGovernance();
+        guardian = _guardian;
+    }
+
+    /// ===== Permissioned Actions: Controller =====
+
+    /// @notice Used to swap any borrowed reserve over the debt limit to liquidate to 'token'
+    /// @notice Only controller can trigger harvests
+    function harvest(address reserve, uint256 amount) external whenNotPaused {
+        _onlyController();
+        require(reserve != address(token), "token");
+        IERC20Upgradeable(reserve).safeTransfer(controller, amount);
+    }
+
+    /// ===== Permissioned Functions: Trusted Actors =====
+
+    /// @notice Transfer the underlying available to be claimed to the controller
+    /// @notice The controller will deposit into the Strategy for yield-generating activities
+    /// @notice Permissionless operation
+    function earn() public whenNotPaused {
+        _onlyAuthorizedActors();
+
+        uint256 _bal = available();
+        token.safeTransfer(controller, _bal);
+        IController(controller).earn(address(token), _bal);
+    }
+
+    /// @dev Emit event tracking current full price per share
+    /// @dev Provides a pure on-chain way of approximating APY
+    function trackFullPricePerShare() external whenNotPaused {
+        _onlyAuthorizedActors();
+        emit FullPricePerShareUpdated(getPricePerFullShare(), now, block.number);
+    }
+
+    function pause() external {
+        _onlyAuthorizedPausers();
+        _pause();
+    }
+
+    function unpause() external {
+        _onlyGovernance();
+        _unpause();
+    }
+
+    /// ===== Internal Implementations =====
+
+    /// @dev Calculate the number of shares to issue for a given deposit
+    /// @dev This is based on the realized value of underlying assets between Sett & associated Strategy
+    function _deposit(uint256 _amount) internal virtual {
+        uint256 _pool = balance();
+        uint256 _before = token.balanceOf(address(this));
+        token.safeTransferFrom(msg.sender, address(this), _amount);
+        uint256 _after = token.balanceOf(address(this));
+        _amount = _after.sub(_before); // Additional check for deflationary tokens
+        uint256 shares = 0;
+        if (totalSupply() == 0) {
+            shares = _amount;
+        } else {
+            shares = (_amount.mul(totalSupply())).div(_pool);
+        }
+        _mint(msg.sender, shares);
+    }
+
+    function _depositWithAuthorization(uint256 _amount, bytes32[] memory proof) internal virtual {
+        if (address(guestList) != address(0)) {
+            require(guestList.authorized(msg.sender, _amount, proof), "guest-list-authorization");
+        }
+        _deposit(_amount);
+    }
+
+    // No rebalance implementation for lower fees and faster swaps
+    function _withdraw(uint256 _shares) internal virtual {
+        uint256 r = (balance().mul(_shares)).div(totalSupply());
+        _burn(msg.sender, _shares);
+
+        // Check balance
+        uint256 b = token.balanceOf(address(this));
+        if (b < r) {
+            uint256 _toWithdraw = r.sub(b);
+            IController(controller).withdraw(address(token), _toWithdraw);
+            uint256 _after = token.balanceOf(address(this));
+            uint256 _diff = _after.sub(b);
+            if (_diff < _toWithdraw) {
+                r = b.add(_diff);
+            }
+        }
+
+        token.safeTransfer(msg.sender, r);
+    }
+
+    function _lockForBlock(address account) internal {
+        blockLock[account] = block.number;
+    }
+
+    /// ===== ERC20 Overrides =====
+
+    /// @dev Add blockLock to transfers, users cannot transfer tokens in the same block as a deposit or withdrawal.
+    function transfer(address recipient, uint256 amount) public virtual override whenNotPaused returns (bool) {
+        _blockLocked();
+        return super.transfer(recipient, amount);
+    }
+
+    function transferFrom(
+        address sender,
+        address recipient,
+        uint256 amount
+    ) public virtual override whenNotPaused returns (bool) {
+        _blockLocked();
+        return super.transferFrom(sender, recipient, amount);
+    }
+}

--- a/contracts/_original/SettV4.sol
+++ b/contracts/_original/SettV4.sol
@@ -1,0 +1,1640 @@
+/**
+ *Submitted for verification at Etherscan.io on 2021-06-21
+*/
+
+// Sources flattened with hardhat v2.0.5 https://hardhat.org
+
+// File deps/@openzeppelin/contracts-upgradeable/token/ERC20/IERC20Upgradeable.sol
+
+// SPDX-License-Identifier: MIT
+
+pragma solidity ^0.6.0;
+
+/**
+ * @dev Interface of the ERC20 standard as defined in the EIP.
+ */
+interface IERC20Upgradeable {
+    /**
+     * @dev Returns the amount of tokens in existence.
+     */
+    function totalSupply() external view returns (uint256);
+
+    /**
+     * @dev Returns the amount of tokens owned by `account`.
+     */
+    function balanceOf(address account) external view returns (uint256);
+
+    /**
+     * @dev Moves `amount` tokens from the caller's account to `recipient`.
+     *
+     * Returns a boolean value indicating whether the operation succeeded.
+     *
+     * Emits a {Transfer} event.
+     */
+    function transfer(address recipient, uint256 amount) external returns (bool);
+
+    /**
+     * @dev Returns the remaining number of tokens that `spender` will be
+     * allowed to spend on behalf of `owner` through {transferFrom}. This is
+     * zero by default.
+     *
+     * This value changes when {approve} or {transferFrom} are called.
+     */
+    function allowance(address owner, address spender) external view returns (uint256);
+
+    /**
+     * @dev Sets `amount` as the allowance of `spender` over the caller's tokens.
+     *
+     * Returns a boolean value indicating whether the operation succeeded.
+     *
+     * IMPORTANT: Beware that changing an allowance with this method brings the risk
+     * that someone may use both the old and the new allowance by unfortunate
+     * transaction ordering. One possible solution to mitigate this race
+     * condition is to first reduce the spender's allowance to 0 and set the
+     * desired value afterwards:
+     * https://github.com/ethereum/EIPs/issues/20#issuecomment-263524729
+     *
+     * Emits an {Approval} event.
+     */
+    function approve(address spender, uint256 amount) external returns (bool);
+
+    /**
+     * @dev Moves `amount` tokens from `sender` to `recipient` using the
+     * allowance mechanism. `amount` is then deducted from the caller's
+     * allowance.
+     *
+     * Returns a boolean value indicating whether the operation succeeded.
+     *
+     * Emits a {Transfer} event.
+     */
+    function transferFrom(address sender, address recipient, uint256 amount) external returns (bool);
+
+    /**
+     * @dev Emitted when `value` tokens are moved from one account (`from`) to
+     * another (`to`).
+     *
+     * Note that `value` may be zero.
+     */
+    event Transfer(address indexed from, address indexed to, uint256 value);
+
+    /**
+     * @dev Emitted when the allowance of a `spender` for an `owner` is set by
+     * a call to {approve}. `value` is the new allowance.
+     */
+    event Approval(address indexed owner, address indexed spender, uint256 value);
+}
+
+
+// File deps/@openzeppelin/contracts-upgradeable/math/SafeMathUpgradeable.sol
+
+
+
+pragma solidity ^0.6.0;
+
+/**
+ * @dev Wrappers over Solidity's arithmetic operations with added overflow
+ * checks.
+ *
+ * Arithmetic operations in Solidity wrap on overflow. This can easily result
+ * in bugs, because programmers usually assume that an overflow raises an
+ * error, which is the standard behavior in high level programming languages.
+ * `SafeMath` restores this intuition by reverting the transaction when an
+ * operation overflows.
+ *
+ * Using this library instead of the unchecked operations eliminates an entire
+ * class of bugs, so it's recommended to use it always.
+ */
+library SafeMathUpgradeable {
+    /**
+     * @dev Returns the addition of two unsigned integers, reverting on
+     * overflow.
+     *
+     * Counterpart to Solidity's `+` operator.
+     *
+     * Requirements:
+     *
+     * - Addition cannot overflow.
+     */
+    function add(uint256 a, uint256 b) internal pure returns (uint256) {
+        uint256 c = a + b;
+        require(c >= a, "SafeMath: addition overflow");
+
+        return c;
+    }
+
+    /**
+     * @dev Returns the subtraction of two unsigned integers, reverting on
+     * overflow (when the result is negative).
+     *
+     * Counterpart to Solidity's `-` operator.
+     *
+     * Requirements:
+     *
+     * - Subtraction cannot overflow.
+     */
+    function sub(uint256 a, uint256 b) internal pure returns (uint256) {
+        return sub(a, b, "SafeMath: subtraction overflow");
+    }
+
+    /**
+     * @dev Returns the subtraction of two unsigned integers, reverting with custom message on
+     * overflow (when the result is negative).
+     *
+     * Counterpart to Solidity's `-` operator.
+     *
+     * Requirements:
+     *
+     * - Subtraction cannot overflow.
+     */
+    function sub(uint256 a, uint256 b, string memory errorMessage) internal pure returns (uint256) {
+        require(b <= a, errorMessage);
+        uint256 c = a - b;
+
+        return c;
+    }
+
+    /**
+     * @dev Returns the multiplication of two unsigned integers, reverting on
+     * overflow.
+     *
+     * Counterpart to Solidity's `*` operator.
+     *
+     * Requirements:
+     *
+     * - Multiplication cannot overflow.
+     */
+    function mul(uint256 a, uint256 b) internal pure returns (uint256) {
+        // Gas optimization: this is cheaper than requiring 'a' not being zero, but the
+        // benefit is lost if 'b' is also tested.
+        // See: https://github.com/OpenZeppelin/openzeppelin-contracts/pull/522
+        if (a == 0) {
+            return 0;
+        }
+
+        uint256 c = a * b;
+        require(c / a == b, "SafeMath: multiplication overflow");
+
+        return c;
+    }
+
+    /**
+     * @dev Returns the integer division of two unsigned integers. Reverts on
+     * division by zero. The result is rounded towards zero.
+     *
+     * Counterpart to Solidity's `/` operator. Note: this function uses a
+     * `revert` opcode (which leaves remaining gas untouched) while Solidity
+     * uses an invalid opcode to revert (consuming all remaining gas).
+     *
+     * Requirements:
+     *
+     * - The divisor cannot be zero.
+     */
+    function div(uint256 a, uint256 b) internal pure returns (uint256) {
+        return div(a, b, "SafeMath: division by zero");
+    }
+
+    /**
+     * @dev Returns the integer division of two unsigned integers. Reverts with custom message on
+     * division by zero. The result is rounded towards zero.
+     *
+     * Counterpart to Solidity's `/` operator. Note: this function uses a
+     * `revert` opcode (which leaves remaining gas untouched) while Solidity
+     * uses an invalid opcode to revert (consuming all remaining gas).
+     *
+     * Requirements:
+     *
+     * - The divisor cannot be zero.
+     */
+    function div(uint256 a, uint256 b, string memory errorMessage) internal pure returns (uint256) {
+        require(b > 0, errorMessage);
+        uint256 c = a / b;
+        // assert(a == b * c + a % b); // There is no case in which this doesn't hold
+
+        return c;
+    }
+
+    /**
+     * @dev Returns the remainder of dividing two unsigned integers. (unsigned integer modulo),
+     * Reverts when dividing by zero.
+     *
+     * Counterpart to Solidity's `%` operator. This function uses a `revert`
+     * opcode (which leaves remaining gas untouched) while Solidity uses an
+     * invalid opcode to revert (consuming all remaining gas).
+     *
+     * Requirements:
+     *
+     * - The divisor cannot be zero.
+     */
+    function mod(uint256 a, uint256 b) internal pure returns (uint256) {
+        return mod(a, b, "SafeMath: modulo by zero");
+    }
+
+    /**
+     * @dev Returns the remainder of dividing two unsigned integers. (unsigned integer modulo),
+     * Reverts with custom message when dividing by zero.
+     *
+     * Counterpart to Solidity's `%` operator. This function uses a `revert`
+     * opcode (which leaves remaining gas untouched) while Solidity uses an
+     * invalid opcode to revert (consuming all remaining gas).
+     *
+     * Requirements:
+     *
+     * - The divisor cannot be zero.
+     */
+    function mod(uint256 a, uint256 b, string memory errorMessage) internal pure returns (uint256) {
+        require(b != 0, errorMessage);
+        return a % b;
+    }
+}
+
+
+// File deps/@openzeppelin/contracts-upgradeable/utils/AddressUpgradeable.sol
+
+
+
+pragma solidity ^0.6.2;
+
+/**
+ * @dev Collection of functions related to the address type
+ */
+library AddressUpgradeable {
+    /**
+     * @dev Returns true if `account` is a contract.
+     *
+     * [IMPORTANT]
+     * ====
+     * It is unsafe to assume that an address for which this function returns
+     * false is an externally-owned account (EOA) and not a contract.
+     *
+     * Among others, `isContract` will return false for the following
+     * types of addresses:
+     *
+     *  - an externally-owned account
+     *  - a contract in construction
+     *  - an address where a contract will be created
+     *  - an address where a contract lived, but was destroyed
+     * ====
+     */
+    function isContract(address account) internal view returns (bool) {
+        // This method relies in extcodesize, which returns 0 for contracts in
+        // construction, since the code is only stored at the end of the
+        // constructor execution.
+
+        uint256 size;
+        // solhint-disable-next-line no-inline-assembly
+        assembly { size := extcodesize(account) }
+        return size > 0;
+    }
+
+    /**
+     * @dev Replacement for Solidity's `transfer`: sends `amount` wei to
+     * `recipient`, forwarding all available gas and reverting on errors.
+     *
+     * https://eips.ethereum.org/EIPS/eip-1884[EIP1884] increases the gas cost
+     * of certain opcodes, possibly making contracts go over the 2300 gas limit
+     * imposed by `transfer`, making them unable to receive funds via
+     * `transfer`. {sendValue} removes this limitation.
+     *
+     * https://diligence.consensys.net/posts/2019/09/stop-using-soliditys-transfer-now/[Learn more].
+     *
+     * IMPORTANT: because control is transferred to `recipient`, care must be
+     * taken to not create reentrancy vulnerabilities. Consider using
+     * {ReentrancyGuard} or the
+     * https://solidity.readthedocs.io/en/v0.5.11/security-considerations.html#use-the-checks-effects-interactions-pattern[checks-effects-interactions pattern].
+     */
+    function sendValue(address payable recipient, uint256 amount) internal {
+        require(address(this).balance >= amount, "Address: insufficient balance");
+
+        // solhint-disable-next-line avoid-low-level-calls, avoid-call-value
+        (bool success, ) = recipient.call{ value: amount }("");
+        require(success, "Address: unable to send value, recipient may have reverted");
+    }
+
+    /**
+     * @dev Performs a Solidity function call using a low level `call`. A
+     * plain`call` is an unsafe replacement for a function call: use this
+     * function instead.
+     *
+     * If `target` reverts with a revert reason, it is bubbled up by this
+     * function (like regular Solidity function calls).
+     *
+     * Returns the raw returned data. To convert to the expected return value,
+     * use https://solidity.readthedocs.io/en/latest/units-and-global-variables.html?highlight=abi.decode#abi-encoding-and-decoding-functions[`abi.decode`].
+     *
+     * Requirements:
+     *
+     * - `target` must be a contract.
+     * - calling `target` with `data` must not revert.
+     *
+     * _Available since v3.1._
+     */
+    function functionCall(address target, bytes memory data) internal returns (bytes memory) {
+      return functionCall(target, data, "Address: low-level call failed");
+    }
+
+    /**
+     * @dev Same as {xref-Address-functionCall-address-bytes-}[`functionCall`], but with
+     * `errorMessage` as a fallback revert reason when `target` reverts.
+     *
+     * _Available since v3.1._
+     */
+    function functionCall(address target, bytes memory data, string memory errorMessage) internal returns (bytes memory) {
+        return _functionCallWithValue(target, data, 0, errorMessage);
+    }
+
+    /**
+     * @dev Same as {xref-Address-functionCall-address-bytes-}[`functionCall`],
+     * but also transferring `value` wei to `target`.
+     *
+     * Requirements:
+     *
+     * - the calling contract must have an ETH balance of at least `value`.
+     * - the called Solidity function must be `payable`.
+     *
+     * _Available since v3.1._
+     */
+    function functionCallWithValue(address target, bytes memory data, uint256 value) internal returns (bytes memory) {
+        return functionCallWithValue(target, data, value, "Address: low-level call with value failed");
+    }
+
+    /**
+     * @dev Same as {xref-Address-functionCallWithValue-address-bytes-uint256-}[`functionCallWithValue`], but
+     * with `errorMessage` as a fallback revert reason when `target` reverts.
+     *
+     * _Available since v3.1._
+     */
+    function functionCallWithValue(address target, bytes memory data, uint256 value, string memory errorMessage) internal returns (bytes memory) {
+        require(address(this).balance >= value, "Address: insufficient balance for call");
+        return _functionCallWithValue(target, data, value, errorMessage);
+    }
+
+    function _functionCallWithValue(address target, bytes memory data, uint256 weiValue, string memory errorMessage) private returns (bytes memory) {
+        require(isContract(target), "Address: call to non-contract");
+
+        // solhint-disable-next-line avoid-low-level-calls
+        (bool success, bytes memory returndata) = target.call{ value: weiValue }(data);
+        if (success) {
+            return returndata;
+        } else {
+            // Look for revert reason and bubble it up if present
+            if (returndata.length > 0) {
+                // The easiest way to bubble the revert reason is using memory via assembly
+
+                // solhint-disable-next-line no-inline-assembly
+                assembly {
+                    let returndata_size := mload(returndata)
+                    revert(add(32, returndata), returndata_size)
+                }
+            } else {
+                revert(errorMessage);
+            }
+        }
+    }
+}
+
+
+// File deps/@openzeppelin/contracts-upgradeable/token/ERC20/SafeERC20Upgradeable.sol
+
+
+
+pragma solidity ^0.6.0;
+
+
+
+/**
+ * @title SafeERC20
+ * @dev Wrappers around ERC20 operations that throw on failure (when the token
+ * contract returns false). Tokens that return no value (and instead revert or
+ * throw on failure) are also supported, non-reverting calls are assumed to be
+ * successful.
+ * To use this library you can add a `using SafeERC20 for IERC20;` statement to your contract,
+ * which allows you to call the safe operations as `token.safeTransfer(...)`, etc.
+ */
+library SafeERC20Upgradeable {
+    using SafeMathUpgradeable for uint256;
+    using AddressUpgradeable for address;
+
+    function safeTransfer(IERC20Upgradeable token, address to, uint256 value) internal {
+        _callOptionalReturn(token, abi.encodeWithSelector(token.transfer.selector, to, value));
+    }
+
+    function safeTransferFrom(IERC20Upgradeable token, address from, address to, uint256 value) internal {
+        _callOptionalReturn(token, abi.encodeWithSelector(token.transferFrom.selector, from, to, value));
+    }
+
+    /**
+     * @dev Deprecated. This function has issues similar to the ones found in
+     * {IERC20-approve}, and its usage is discouraged.
+     *
+     * Whenever possible, use {safeIncreaseAllowance} and
+     * {safeDecreaseAllowance} instead.
+     */
+    function safeApprove(IERC20Upgradeable token, address spender, uint256 value) internal {
+        // safeApprove should only be called when setting an initial allowance,
+        // or when resetting it to zero. To increase and decrease it, use
+        // 'safeIncreaseAllowance' and 'safeDecreaseAllowance'
+        // solhint-disable-next-line max-line-length
+        require((value == 0) || (token.allowance(address(this), spender) == 0),
+            "SafeERC20: approve from non-zero to non-zero allowance"
+        );
+        _callOptionalReturn(token, abi.encodeWithSelector(token.approve.selector, spender, value));
+    }
+
+    function safeIncreaseAllowance(IERC20Upgradeable token, address spender, uint256 value) internal {
+        uint256 newAllowance = token.allowance(address(this), spender).add(value);
+        _callOptionalReturn(token, abi.encodeWithSelector(token.approve.selector, spender, newAllowance));
+    }
+
+    function safeDecreaseAllowance(IERC20Upgradeable token, address spender, uint256 value) internal {
+        uint256 newAllowance = token.allowance(address(this), spender).sub(value, "SafeERC20: decreased allowance below zero");
+        _callOptionalReturn(token, abi.encodeWithSelector(token.approve.selector, spender, newAllowance));
+    }
+
+    /**
+     * @dev Imitates a Solidity high-level call (i.e. a regular function call to a contract), relaxing the requirement
+     * on the return value: the return value is optional (but if data is returned, it must not be false).
+     * @param token The token targeted by the call.
+     * @param data The call data (encoded using abi.encode or one of its variants).
+     */
+    function _callOptionalReturn(IERC20Upgradeable token, bytes memory data) private {
+        // We need to perform a low level call here, to bypass Solidity's return data size checking mechanism, since
+        // we're implementing it ourselves. We use {Address.functionCall} to perform this call, which verifies that
+        // the target address contains contract code and also asserts for success in the low-level call.
+
+        bytes memory returndata = address(token).functionCall(data, "SafeERC20: low-level call failed");
+        if (returndata.length > 0) { // Return data is optional
+            // solhint-disable-next-line max-line-length
+            require(abi.decode(returndata, (bool)), "SafeERC20: ERC20 operation did not succeed");
+        }
+    }
+}
+
+
+// File deps/@openzeppelin/contracts-upgradeable/proxy/Initializable.sol
+
+
+
+pragma solidity >=0.4.24 <0.7.0;
+
+
+/**
+ * @dev This is a base contract to aid in writing upgradeable contracts, or any kind of contract that will be deployed
+ * behind a proxy. Since a proxied contract can't have a constructor, it's common to move constructor logic to an
+ * external initializer function, usually called `initialize`. It then becomes necessary to protect this initializer
+ * function so it can only be called once. The {initializer} modifier provided by this contract will have this effect.
+ * 
+ * TIP: To avoid leaving the proxy in an uninitialized state, the initializer function should be called as early as
+ * possible by providing the encoded function call as the `_data` argument to {UpgradeableProxy-constructor}.
+ * 
+ * CAUTION: When used with inheritance, manual care must be taken to not invoke a parent initializer twice, or to ensure
+ * that all initializers are idempotent. This is not verified automatically as constructors are by Solidity.
+ */
+abstract contract Initializable {
+
+    /**
+     * @dev Indicates that the contract has been initialized.
+     */
+    bool private _initialized;
+
+    /**
+     * @dev Indicates that the contract is in the process of being initialized.
+     */
+    bool private _initializing;
+
+    /**
+     * @dev Modifier to protect an initializer function from being invoked twice.
+     */
+    modifier initializer() {
+        require(_initializing || _isConstructor() || !_initialized, "Initializable: contract is already initialized");
+
+        bool isTopLevelCall = !_initializing;
+        if (isTopLevelCall) {
+            _initializing = true;
+            _initialized = true;
+        }
+
+        _;
+
+        if (isTopLevelCall) {
+            _initializing = false;
+        }
+    }
+
+    /// @dev Returns true if and only if the function is running in the constructor
+    function _isConstructor() private view returns (bool) {
+        // extcodesize checks the size of the code stored in an address, and
+        // address returns the current address. Since the code is still not
+        // deployed when running a constructor, any checks on its code size will
+        // yield zero, making it an effective way to detect if a contract is
+        // under construction or not.
+        address self = address(this);
+        uint256 cs;
+        // solhint-disable-next-line no-inline-assembly
+        assembly { cs := extcodesize(self) }
+        return cs == 0;
+    }
+}
+
+
+// File deps/@openzeppelin/contracts-upgradeable/GSN/ContextUpgradeable.sol
+
+
+
+pragma solidity ^0.6.0;
+
+/*
+ * @dev Provides information about the current execution context, including the
+ * sender of the transaction and its data. While these are generally available
+ * via msg.sender and msg.data, they should not be accessed in such a direct
+ * manner, since when dealing with GSN meta-transactions the account sending and
+ * paying for execution may not be the actual sender (as far as an application
+ * is concerned).
+ *
+ * This contract is only required for intermediate, library-like contracts.
+ */
+abstract contract ContextUpgradeable is Initializable {
+    function __Context_init() internal initializer {
+        __Context_init_unchained();
+    }
+
+    function __Context_init_unchained() internal initializer {
+    }
+    function _msgSender() internal view virtual returns (address payable) {
+        return msg.sender;
+    }
+
+    function _msgData() internal view virtual returns (bytes memory) {
+        this; // silence state mutability warning without generating bytecode - see https://github.com/ethereum/solidity/issues/2691
+        return msg.data;
+    }
+    uint256[50] private __gap;
+}
+
+
+// File deps/@openzeppelin/contracts-upgradeable/token/ERC20/ERC20Upgradeable.sol
+
+
+
+pragma solidity ^0.6.0;
+
+
+
+
+
+/**
+ * @dev Implementation of the {IERC20} interface.
+ *
+ * This implementation is agnostic to the way tokens are created. This means
+ * that a supply mechanism has to be added in a derived contract using {_mint}.
+ * For a generic mechanism see {ERC20PresetMinterPauser}.
+ *
+ * TIP: For a detailed writeup see our guide
+ * https://forum.zeppelin.solutions/t/how-to-implement-erc20-supply-mechanisms/226[How
+ * to implement supply mechanisms].
+ *
+ * We have followed general OpenZeppelin guidelines: functions revert instead
+ * of returning `false` on failure. This behavior is nonetheless conventional
+ * and does not conflict with the expectations of ERC20 applications.
+ *
+ * Additionally, an {Approval} event is emitted on calls to {transferFrom}.
+ * This allows applications to reconstruct the allowance for all accounts just
+ * by listening to said events. Other implementations of the EIP may not emit
+ * these events, as it isn't required by the specification.
+ *
+ * Finally, the non-standard {decreaseAllowance} and {increaseAllowance}
+ * functions have been added to mitigate the well-known issues around setting
+ * allowances. See {IERC20-approve}.
+ */
+contract ERC20Upgradeable is Initializable, ContextUpgradeable, IERC20Upgradeable {
+    using SafeMathUpgradeable for uint256;
+    using AddressUpgradeable for address;
+
+    mapping (address => uint256) private _balances;
+
+    mapping (address => mapping (address => uint256)) private _allowances;
+
+    uint256 private _totalSupply;
+
+    string private _name;
+    string private _symbol;
+    uint8 private _decimals;
+
+    /**
+     * @dev Sets the values for {name} and {symbol}, initializes {decimals} with
+     * a default value of 18.
+     *
+     * To select a different value for {decimals}, use {_setupDecimals}.
+     *
+     * All three of these values are immutable: they can only be set once during
+     * construction.
+     */
+    function __ERC20_init(string memory name, string memory symbol) internal initializer {
+        __Context_init_unchained();
+        __ERC20_init_unchained(name, symbol);
+    }
+
+    function __ERC20_init_unchained(string memory name, string memory symbol) internal initializer {
+        _name = name;
+        _symbol = symbol;
+        _decimals = 18;
+    }
+
+    /**
+     * @dev Returns the name of the token.
+     */
+    function name() public view returns (string memory) {
+        return _name;
+    }
+
+    /**
+     * @dev Returns the symbol of the token, usually a shorter version of the
+     * name.
+     */
+    function symbol() public view returns (string memory) {
+        return _symbol;
+    }
+
+    /**
+     * @dev Returns the number of decimals used to get its user representation.
+     * For example, if `decimals` equals `2`, a balance of `505` tokens should
+     * be displayed to a user as `5,05` (`505 / 10 ** 2`).
+     *
+     * Tokens usually opt for a value of 18, imitating the relationship between
+     * Ether and Wei. This is the value {ERC20} uses, unless {_setupDecimals} is
+     * called.
+     *
+     * NOTE: This information is only used for _display_ purposes: it in
+     * no way affects any of the arithmetic of the contract, including
+     * {IERC20-balanceOf} and {IERC20-transfer}.
+     */
+    function decimals() public view returns (uint8) {
+        return _decimals;
+    }
+
+    /**
+     * @dev See {IERC20-totalSupply}.
+     */
+    function totalSupply() public view override returns (uint256) {
+        return _totalSupply;
+    }
+
+    /**
+     * @dev See {IERC20-balanceOf}.
+     */
+    function balanceOf(address account) public view override returns (uint256) {
+        return _balances[account];
+    }
+
+    /**
+     * @dev See {IERC20-transfer}.
+     *
+     * Requirements:
+     *
+     * - `recipient` cannot be the zero address.
+     * - the caller must have a balance of at least `amount`.
+     */
+    function transfer(address recipient, uint256 amount) public virtual override returns (bool) {
+        _transfer(_msgSender(), recipient, amount);
+        return true;
+    }
+
+    /**
+     * @dev See {IERC20-allowance}.
+     */
+    function allowance(address owner, address spender) public view virtual override returns (uint256) {
+        return _allowances[owner][spender];
+    }
+
+    /**
+     * @dev See {IERC20-approve}.
+     *
+     * Requirements:
+     *
+     * - `spender` cannot be the zero address.
+     */
+    function approve(address spender, uint256 amount) public virtual override returns (bool) {
+        _approve(_msgSender(), spender, amount);
+        return true;
+    }
+
+    /**
+     * @dev See {IERC20-transferFrom}.
+     *
+     * Emits an {Approval} event indicating the updated allowance. This is not
+     * required by the EIP. See the note at the beginning of {ERC20};
+     *
+     * Requirements:
+     * - `sender` and `recipient` cannot be the zero address.
+     * - `sender` must have a balance of at least `amount`.
+     * - the caller must have allowance for ``sender``'s tokens of at least
+     * `amount`.
+     */
+    function transferFrom(address sender, address recipient, uint256 amount) public virtual override returns (bool) {
+        _transfer(sender, recipient, amount);
+        _approve(sender, _msgSender(), _allowances[sender][_msgSender()].sub(amount, "ERC20: transfer amount exceeds allowance"));
+        return true;
+    }
+
+    /**
+     * @dev Atomically increases the allowance granted to `spender` by the caller.
+     *
+     * This is an alternative to {approve} that can be used as a mitigation for
+     * problems described in {IERC20-approve}.
+     *
+     * Emits an {Approval} event indicating the updated allowance.
+     *
+     * Requirements:
+     *
+     * - `spender` cannot be the zero address.
+     */
+    function increaseAllowance(address spender, uint256 addedValue) public virtual returns (bool) {
+        _approve(_msgSender(), spender, _allowances[_msgSender()][spender].add(addedValue));
+        return true;
+    }
+
+    /**
+     * @dev Atomically decreases the allowance granted to `spender` by the caller.
+     *
+     * This is an alternative to {approve} that can be used as a mitigation for
+     * problems described in {IERC20-approve}.
+     *
+     * Emits an {Approval} event indicating the updated allowance.
+     *
+     * Requirements:
+     *
+     * - `spender` cannot be the zero address.
+     * - `spender` must have allowance for the caller of at least
+     * `subtractedValue`.
+     */
+    function decreaseAllowance(address spender, uint256 subtractedValue) public virtual returns (bool) {
+        _approve(_msgSender(), spender, _allowances[_msgSender()][spender].sub(subtractedValue, "ERC20: decreased allowance below zero"));
+        return true;
+    }
+
+    /**
+     * @dev Moves tokens `amount` from `sender` to `recipient`.
+     *
+     * This is internal function is equivalent to {transfer}, and can be used to
+     * e.g. implement automatic token fees, slashing mechanisms, etc.
+     *
+     * Emits a {Transfer} event.
+     *
+     * Requirements:
+     *
+     * - `sender` cannot be the zero address.
+     * - `recipient` cannot be the zero address.
+     * - `sender` must have a balance of at least `amount`.
+     */
+    function _transfer(address sender, address recipient, uint256 amount) internal virtual {
+        require(sender != address(0), "ERC20: transfer from the zero address");
+        require(recipient != address(0), "ERC20: transfer to the zero address");
+
+        _beforeTokenTransfer(sender, recipient, amount);
+
+        _balances[sender] = _balances[sender].sub(amount, "ERC20: transfer amount exceeds balance");
+        _balances[recipient] = _balances[recipient].add(amount);
+        emit Transfer(sender, recipient, amount);
+    }
+
+    /** @dev Creates `amount` tokens and assigns them to `account`, increasing
+     * the total supply.
+     *
+     * Emits a {Transfer} event with `from` set to the zero address.
+     *
+     * Requirements
+     *
+     * - `to` cannot be the zero address.
+     */
+    function _mint(address account, uint256 amount) internal virtual {
+        require(account != address(0), "ERC20: mint to the zero address");
+
+        _beforeTokenTransfer(address(0), account, amount);
+
+        _totalSupply = _totalSupply.add(amount);
+        _balances[account] = _balances[account].add(amount);
+        emit Transfer(address(0), account, amount);
+    }
+
+    /**
+     * @dev Destroys `amount` tokens from `account`, reducing the
+     * total supply.
+     *
+     * Emits a {Transfer} event with `to` set to the zero address.
+     *
+     * Requirements
+     *
+     * - `account` cannot be the zero address.
+     * - `account` must have at least `amount` tokens.
+     */
+    function _burn(address account, uint256 amount) internal virtual {
+        require(account != address(0), "ERC20: burn from the zero address");
+
+        _beforeTokenTransfer(account, address(0), amount);
+
+        _balances[account] = _balances[account].sub(amount, "ERC20: burn amount exceeds balance");
+        _totalSupply = _totalSupply.sub(amount);
+        emit Transfer(account, address(0), amount);
+    }
+
+    /**
+     * @dev Sets `amount` as the allowance of `spender` over the `owner` s tokens.
+     *
+     * This internal function is equivalent to `approve`, and can be used to
+     * e.g. set automatic allowances for certain subsystems, etc.
+     *
+     * Emits an {Approval} event.
+     *
+     * Requirements:
+     *
+     * - `owner` cannot be the zero address.
+     * - `spender` cannot be the zero address.
+     */
+    function _approve(address owner, address spender, uint256 amount) internal virtual {
+        require(owner != address(0), "ERC20: approve from the zero address");
+        require(spender != address(0), "ERC20: approve to the zero address");
+
+        _allowances[owner][spender] = amount;
+        emit Approval(owner, spender, amount);
+    }
+
+    /**
+     * @dev Sets {decimals} to a value other than the default one of 18.
+     *
+     * WARNING: This function should only be called from the constructor. Most
+     * applications that interact with token contracts will not expect
+     * {decimals} to ever change, and may work incorrectly if it does.
+     */
+    function _setupDecimals(uint8 decimals_) internal {
+        _decimals = decimals_;
+    }
+
+    /**
+     * @dev Hook that is called before any transfer of tokens. This includes
+     * minting and burning.
+     *
+     * Calling conditions:
+     *
+     * - when `from` and `to` are both non-zero, `amount` of ``from``'s tokens
+     * will be to transferred to `to`.
+     * - when `from` is zero, `amount` tokens will be minted for `to`.
+     * - when `to` is zero, `amount` of ``from``'s tokens will be burned.
+     * - `from` and `to` are never both zero.
+     *
+     * To learn more about hooks, head to xref:ROOT:extending-contracts.adoc#using-hooks[Using Hooks].
+     */
+    function _beforeTokenTransfer(address from, address to, uint256 amount) internal virtual { }
+    uint256[44] private __gap;
+}
+
+
+// File deps/@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol
+
+
+
+pragma solidity ^0.6.0;
+
+
+/**
+ * @dev Contract module which provides a basic access control mechanism, where
+ * there is an account (an owner) that can be granted exclusive access to
+ * specific functions.
+ *
+ * By default, the owner account will be the one that deploys the contract. This
+ * can later be changed with {transferOwnership}.
+ *
+ * This module is used through inheritance. It will make available the modifier
+ * `onlyOwner`, which can be applied to your functions to restrict their use to
+ * the owner.
+ */
+contract OwnableUpgradeable is Initializable, ContextUpgradeable {
+    address private _owner;
+
+    event OwnershipTransferred(address indexed previousOwner, address indexed newOwner);
+
+    /**
+     * @dev Initializes the contract setting the deployer as the initial owner.
+     */
+    function __Ownable_init() internal initializer {
+        __Context_init_unchained();
+        __Ownable_init_unchained();
+    }
+
+    function __Ownable_init_unchained() internal initializer {
+        address msgSender = _msgSender();
+        _owner = msgSender;
+        emit OwnershipTransferred(address(0), msgSender);
+    }
+
+    /**
+     * @dev Returns the address of the current owner.
+     */
+    function owner() public view returns (address) {
+        return _owner;
+    }
+
+    /**
+     * @dev Throws if called by any account other than the owner.
+     */
+    modifier onlyOwner() {
+        require(_owner == _msgSender(), "Ownable: caller is not the owner");
+        _;
+    }
+
+    /**
+     * @dev Leaves the contract without owner. It will not be possible to call
+     * `onlyOwner` functions anymore. Can only be called by the current owner.
+     *
+     * NOTE: Renouncing ownership will leave the contract without an owner,
+     * thereby removing any functionality that is only available to the owner.
+     */
+    function renounceOwnership() public virtual onlyOwner {
+        emit OwnershipTransferred(_owner, address(0));
+        _owner = address(0);
+    }
+
+    /**
+     * @dev Transfers ownership of the contract to a new account (`newOwner`).
+     * Can only be called by the current owner.
+     */
+    function transferOwnership(address newOwner) public virtual onlyOwner {
+        require(newOwner != address(0), "Ownable: new owner is the zero address");
+        emit OwnershipTransferred(_owner, newOwner);
+        _owner = newOwner;
+    }
+    uint256[49] private __gap;
+}
+
+
+// File deps/@openzeppelin/contracts-upgradeable/utils/PausableUpgradeable.sol
+
+
+
+pragma solidity ^0.6.0;
+
+
+/**
+ * @dev Contract module which allows children to implement an emergency stop
+ * mechanism that can be triggered by an authorized account.
+ *
+ * This module is used through inheritance. It will make available the
+ * modifiers `whenNotPaused` and `whenPaused`, which can be applied to
+ * the functions of your contract. Note that they will not be pausable by
+ * simply including this module, only once the modifiers are put in place.
+ */
+contract PausableUpgradeable is Initializable, ContextUpgradeable {
+    /**
+     * @dev Emitted when the pause is triggered by `account`.
+     */
+    event Paused(address account);
+
+    /**
+     * @dev Emitted when the pause is lifted by `account`.
+     */
+    event Unpaused(address account);
+
+    bool private _paused;
+
+    /**
+     * @dev Initializes the contract in unpaused state.
+     */
+    function __Pausable_init() internal initializer {
+        __Context_init_unchained();
+        __Pausable_init_unchained();
+    }
+
+    function __Pausable_init_unchained() internal initializer {
+        _paused = false;
+    }
+
+    /**
+     * @dev Returns true if the contract is paused, and false otherwise.
+     */
+    function paused() public view returns (bool) {
+        return _paused;
+    }
+
+    /**
+     * @dev Modifier to make a function callable only when the contract is not paused.
+     *
+     * Requirements:
+     *
+     * - The contract must not be paused.
+     */
+    modifier whenNotPaused() {
+        require(!_paused, "Pausable: paused");
+        _;
+    }
+
+    /**
+     * @dev Modifier to make a function callable only when the contract is paused.
+     *
+     * Requirements:
+     *
+     * - The contract must be paused.
+     */
+    modifier whenPaused() {
+        require(_paused, "Pausable: not paused");
+        _;
+    }
+
+    /**
+     * @dev Triggers stopped state.
+     *
+     * Requirements:
+     *
+     * - The contract must not be paused.
+     */
+    function _pause() internal virtual whenNotPaused {
+        _paused = true;
+        emit Paused(_msgSender());
+    }
+
+    /**
+     * @dev Returns to normal state.
+     *
+     * Requirements:
+     *
+     * - The contract must be paused.
+     */
+    function _unpause() internal virtual whenPaused {
+        _paused = false;
+        emit Unpaused(_msgSender());
+    }
+    uint256[49] private __gap;
+}
+
+
+// File interfaces/badger/IController.sol
+
+
+pragma solidity >=0.5.0 <0.8.0;
+
+interface IController {
+    function withdraw(address, uint256) external;
+
+    function strategies(address) external view returns (address);
+
+    function approvedStrategies(address, address) external view returns (address);
+
+    function balanceOf(address) external view returns (uint256);
+
+    function earn(address, uint256) external;
+
+    function approveStrategy(address, address) external;
+
+    function setStrategy(address, address) external;
+
+    function setVault(address, address) external;
+
+    function want(address) external view returns (address);
+
+    function rewards() external view returns (address);
+
+    function vaults(address) external view returns (address);
+}
+
+
+// File interfaces/erc20/IERC20Detailed.sol
+
+
+
+pragma solidity ^0.6.0;
+
+/**
+ * @dev Interface of the ERC20 standard as defined in the EIP.
+ */
+interface IERC20Detailed {
+    /**
+     * @dev Returns the amount of tokens in existence.
+     */
+    function totalSupply() external view returns (uint256);
+
+    function name() external view returns (string memory);
+    function symbol() external view returns (string memory);
+
+    /**
+     * @dev Returns the amount of tokens owned by `account`.
+     */
+    function balanceOf(address account) external view returns (uint256);
+
+    /**
+     * @dev Moves `amount` tokens from the caller's account to `recipient`.
+     *
+     * Returns a boolean value indicating whether the operation succeeded.
+     *
+     * Emits a {Transfer} event.
+     */
+    function transfer(address recipient, uint256 amount) external returns (bool);
+
+    /**
+     * @dev Returns the remaining number of tokens that `spender` will be
+     * allowed to spend on behalf of `owner` through {transferFrom}. This is
+     * zero by default.
+     *
+     * This value changes when {approve} or {transferFrom} are called.
+     */
+    function allowance(address owner, address spender) external view returns (uint256);
+
+    /**
+     * @dev Sets `amount` as the allowance of `spender` over the caller's tokens.
+     *
+     * Returns a boolean value indicating whether the operation succeeded.
+     *
+     * IMPORTANT: Beware that changing an allowance with this method brings the risk
+     * that someone may use both the old and the new allowance by unfortunate
+     * transaction ordering. One possible solution to mitigate this race
+     * condition is to first reduce the spender's allowance to 0 and set the
+     * desired value afterwards:
+     * https://github.com/ethereum/EIPs/issues/20#issuecomment-263524729
+     *
+     * Emits an {Approval} event.
+     */
+    function approve(address spender, uint256 amount) external returns (bool);
+
+    /**
+     * @dev Moves `amount` tokens from `sender` to `recipient` using the
+     * allowance mechanism. `amount` is then deducted from the caller's
+     * allowance.
+     *
+     * Returns a boolean value indicating whether the operation succeeded.
+     *
+     * Emits a {Transfer} event.
+     */
+    function transferFrom(address sender, address recipient, uint256 amount) external returns (bool);
+
+    /**
+     * @dev Emitted when `value` tokens are moved from one account (`from`) to
+     * another (`to`).
+     *
+     * Note that `value` may be zero.
+     */
+    event Transfer(address indexed from, address indexed to, uint256 value);
+
+    /**
+     * @dev Emitted when the allowance of a `spender` for an `owner` is set by
+     * a call to {approve}. `value` is the new allowance.
+     */
+    event Approval(address indexed owner, address indexed spender, uint256 value);
+}
+
+
+// File contracts/badger-sett/SettAccessControl.sol
+
+
+pragma solidity ^0.6.11;
+
+/*
+    Common base for permissioned roles throughout Sett ecosystem
+*/
+contract SettAccessControl is Initializable {
+    address public governance;
+    address public strategist;
+    address public keeper;
+
+    // ===== MODIFIERS =====
+    function _onlyGovernance() internal view {
+        require(msg.sender == governance, "onlyGovernance");
+    }
+
+    function _onlyGovernanceOrStrategist() internal view {
+        require(msg.sender == strategist || msg.sender == governance, "onlyGovernanceOrStrategist");
+    }
+
+    function _onlyAuthorizedActors() internal view {
+        require(msg.sender == keeper || msg.sender == governance, "onlyAuthorizedActors");
+    }
+
+    // ===== PERMISSIONED ACTIONS =====
+
+    /// @notice Change strategist address
+    /// @notice Can only be changed by governance itself
+    function setStrategist(address _strategist) external {
+        _onlyGovernance();
+        strategist = _strategist;
+    }
+
+    /// @notice Change keeper address
+    /// @notice Can only be changed by governance itself
+    function setKeeper(address _keeper) external {
+        _onlyGovernance();
+        keeper = _keeper;
+    }
+
+    /// @notice Change governance address
+    /// @notice Can only be changed by governance itself
+    function setGovernance(address _governance) public {
+        _onlyGovernance();
+        governance = _governance;
+    }
+
+    uint256[50] private __gap;
+}
+
+
+// File contracts/badger-sett/SettAccessControlDefended.sol
+
+
+pragma solidity ^0.6.11;
+
+/*
+    Add ability to prevent unwanted contract access to Sett permissions
+*/
+contract SettAccessControlDefended is SettAccessControl {
+    mapping (address => bool) public approved;
+
+    function approveContractAccess(address account) external {
+        _onlyGovernance();
+        approved[account] = true;
+    }
+
+    function revokeContractAccess(address account) external {
+        _onlyGovernance();
+        approved[account] = false;
+    }
+
+    function _defend() internal view returns (bool) {
+        require(approved[msg.sender] || msg.sender == tx.origin, "Access denied for caller");
+    }
+    uint256[50] private __gap;
+}
+
+
+// File interfaces/yearn/BadgerGuestlistApi.sol
+
+
+pragma solidity >=0.6.0 <0.7.0;
+
+interface BadgerGuestListAPI {
+    function authorized(address guest, uint256 amount, bytes32[] calldata merkleProof) external view returns (bool);
+    function setGuests(address[] calldata _guests, bool[] calldata _invited) external;
+}
+
+
+// File contracts/badger-sett/SettV4.sol
+
+
+
+pragma solidity ^0.6.11;
+
+
+
+
+
+
+
+
+
+
+/* 
+    Source: https://github.com/iearn-finance/yearn-protocol/blob/develop/contracts/vaults/yVault.sol
+    
+    Changelog:
+
+    V1.1
+    * Strategist no longer has special function calling permissions
+    * Version function added to contract
+    * All write functions, with the exception of transfer, are pausable
+    * Keeper or governance can pause
+    * Only governance can unpause
+
+    V1.2
+    * Transfer functions are now pausable along with all other non-permissioned write functions
+    * All permissioned write functions, with the exception of pause() & unpause(), are pausable as well
+
+    V1.3
+    * Add guest list functionality
+    * All deposits can be optionally gated by external guestList approval logic on set guestList contract
+
+    V1.4
+    * Add depositFor() to deposit on the half of other users. That user will then be blockLocked.
+*/
+
+contract SettV4 is ERC20Upgradeable, SettAccessControlDefended, PausableUpgradeable {
+    using SafeERC20Upgradeable for IERC20Upgradeable;
+    using AddressUpgradeable for address;
+    using SafeMathUpgradeable for uint256;
+
+    IERC20Upgradeable public token;
+
+    uint256 public min;
+    uint256 public constant max = 10000;
+
+    address public controller;
+
+    mapping(address => uint256) public blockLock;
+
+    string internal constant _defaultNamePrefix = "Badger Sett ";
+    string internal constant _symbolSymbolPrefix = "b";
+
+    address public guardian;
+
+    BadgerGuestListAPI public guestList;
+
+    event FullPricePerShareUpdated(uint256 value, uint256 indexed timestamp, uint256 indexed blockNumber);
+
+    function initialize(
+        address _token,
+        address _controller,
+        address _governance,
+        address _keeper,
+        address _guardian,
+        bool _overrideTokenName,
+        string memory _namePrefix,
+        string memory _symbolPrefix
+    ) public initializer whenNotPaused {
+        IERC20Detailed namedToken = IERC20Detailed(_token);
+        string memory tokenName = namedToken.name();
+        string memory tokenSymbol = namedToken.symbol();
+
+        string memory name;
+        string memory symbol;
+
+        if (_overrideTokenName) {
+            name = string(abi.encodePacked(_namePrefix, tokenName));
+            symbol = string(abi.encodePacked(_symbolPrefix, tokenSymbol));
+        } else {
+            name = string(abi.encodePacked(_defaultNamePrefix, tokenName));
+            symbol = string(abi.encodePacked(_symbolSymbolPrefix, tokenSymbol));
+        }
+
+        __ERC20_init(name, symbol);
+
+        token = IERC20Upgradeable(_token);
+        governance = _governance;
+        strategist = address(0);
+        keeper = _keeper;
+        controller = _controller;
+        guardian = _guardian;
+
+        min = 9500;
+
+        emit FullPricePerShareUpdated(getPricePerFullShare(), now, block.number);
+
+        // Paused on launch
+        _pause();
+    }
+
+    /// ===== Modifiers =====
+
+    function _onlyController() internal view {
+        require(msg.sender == controller, "onlyController");
+    }
+
+    function _onlyAuthorizedPausers() internal view {
+        require(msg.sender == guardian || msg.sender == governance, "onlyPausers");
+    }
+
+    function _blockLocked() internal view {
+        require(blockLock[msg.sender] < block.number, "blockLocked");
+    }
+
+    /// ===== View Functions =====
+
+    function version() public view returns (string memory) {
+        return "1.4";
+    }
+
+    function getPricePerFullShare() public view virtual returns (uint256) {
+        if (totalSupply() == 0) {
+            return 1e18;
+        }
+        return balance().mul(1e18).div(totalSupply());
+    }
+
+    /// @notice Return the total balance of the underlying token within the system
+    /// @notice Sums the balance in the Sett, the Controller, and the Strategy
+    function balance() public view virtual returns (uint256) {
+        return token.balanceOf(address(this)).add(IController(controller).balanceOf(address(token)));
+    }
+
+    /// @notice Defines how much of the Setts' underlying can be borrowed by the Strategy for use
+    /// @notice Custom logic in here for how much the vault allows to be borrowed
+    /// @notice Sets minimum required on-hand to keep small withdrawals cheap
+    function available() public view virtual returns (uint256) {
+        return token.balanceOf(address(this)).mul(min).div(max);
+    }
+
+    /// ===== Public Actions =====
+
+    /// @notice Deposit assets into the Sett, and return corresponding shares to the user
+    /// @notice Only callable by EOA accounts that pass the _defend() check
+    function deposit(uint256 _amount) public whenNotPaused {
+        _defend();
+        _blockLocked();
+
+        _lockForBlock(msg.sender);
+        _depositWithAuthorization(_amount, new bytes32[](0));
+    }
+
+    /// @notice Deposit variant with proof for merkle guest list
+    function deposit(uint256 _amount, bytes32[] memory proof) public whenNotPaused {
+        _defend();
+        _blockLocked();
+
+        _lockForBlock(msg.sender);
+        _depositWithAuthorization(_amount, proof);
+    }
+
+    /// @notice Convenience function: Deposit entire balance of asset into the Sett, and return corresponding shares to the user
+    /// @notice Only callable by EOA accounts that pass the _defend() check
+    function depositAll() external whenNotPaused {
+        _defend();
+        _blockLocked();
+
+        _lockForBlock(msg.sender);
+        _depositWithAuthorization(token.balanceOf(msg.sender), new bytes32[](0));
+    }
+
+    /// @notice DepositAll variant with proof for merkle guest list
+    function depositAll(bytes32[] memory proof) external whenNotPaused {
+        _defend();
+        _blockLocked();
+
+        _lockForBlock(msg.sender);
+        _depositWithAuthorization(token.balanceOf(msg.sender), proof);
+    }
+
+    /// @notice Deposit assets into the Sett, and return corresponding shares to the user
+    /// @notice Only callable by EOA accounts that pass the _defend() check
+    function depositFor(address _recipient, uint256 _amount) public whenNotPaused {
+        _defend();
+        _blockLocked();
+
+        _lockForBlock(_recipient);
+        _depositForWithAuthorization(_recipient, _amount, new bytes32[](0));
+    }
+
+    /// @notice Deposit variant with proof for merkle guest list
+    function depositFor(address _recipient, uint256 _amount, bytes32[] memory proof) public whenNotPaused {
+        _defend();
+        _blockLocked();
+
+        _lockForBlock(_recipient);
+        _depositForWithAuthorization(_recipient, _amount, proof);
+    }
+
+    /// @notice No rebalance implementation for lower fees and faster swaps
+    function withdraw(uint256 _shares) public whenNotPaused {
+        _defend();
+        _blockLocked();
+
+        _lockForBlock(msg.sender);
+        _withdraw(_shares);
+    }
+
+    /// @notice Convenience function: Withdraw all shares of the sender
+    function withdrawAll() external whenNotPaused {
+        _defend();
+        _blockLocked();
+
+        _lockForBlock(msg.sender);
+        _withdraw(balanceOf(msg.sender));
+    }
+
+    /// ===== Permissioned Actions: Governance =====
+
+    function setGuestList(address _guestList) external whenNotPaused {
+        _onlyGovernance();
+        guestList = BadgerGuestListAPI(_guestList);
+    }
+
+    /// @notice Set minimum threshold of underlying that must be deposited in strategy
+    /// @notice Can only be changed by governance
+    function setMin(uint256 _min) external whenNotPaused {
+        _onlyGovernance();
+        min = _min;
+    }
+
+    /// @notice Change controller address
+    /// @notice Can only be changed by governance
+    function setController(address _controller) public whenNotPaused {
+        _onlyGovernance();
+        controller = _controller;
+    }
+
+    /// @notice Change guardian address
+    /// @notice Can only be changed by governance
+    function setGuardian(address _guardian) external whenNotPaused {
+        _onlyGovernance();
+        guardian = _guardian;
+    }
+
+    /// ===== Permissioned Actions: Controller =====
+
+    /// @notice Used to swap any borrowed reserve over the debt limit to liquidate to 'token'
+    /// @notice Only controller can trigger harvests
+    function harvest(address reserve, uint256 amount) external whenNotPaused {
+        _onlyController();
+        require(reserve != address(token), "token");
+        IERC20Upgradeable(reserve).safeTransfer(controller, amount);
+    }
+
+    /// ===== Permissioned Functions: Trusted Actors =====
+
+    /// @notice Transfer the underlying available to be claimed to the controller
+    /// @notice The controller will deposit into the Strategy for yield-generating activities
+    /// @notice Permissionless operation
+    function earn() public whenNotPaused {
+        _onlyAuthorizedActors();
+
+        uint256 _bal = available();
+        token.safeTransfer(controller, _bal);
+        IController(controller).earn(address(token), _bal);
+    }
+
+    /// @dev Emit event tracking current full price per share
+    /// @dev Provides a pure on-chain way of approximating APY
+    function trackFullPricePerShare() external whenNotPaused {
+        _onlyAuthorizedActors();
+        emit FullPricePerShareUpdated(getPricePerFullShare(), now, block.number);
+    }
+
+    function pause() external {
+        _onlyAuthorizedPausers();
+        _pause();
+    }
+
+    function unpause() external {
+        _onlyGovernance();
+        _unpause();
+    }
+
+    /// ===== Internal Implementations =====
+
+    /// @dev Calculate the number of shares to issue for a given deposit
+    /// @dev This is based on the realized value of underlying assets between Sett & associated Strategy
+    // @dev deposit for msg.sender
+    function _deposit(uint256 _amount) internal {
+        _depositFor(msg.sender, _amount);
+    }
+
+    function _depositFor(address recipient, uint256 _amount) internal virtual {
+        uint256 _pool = balance();
+        uint256 _before = token.balanceOf(address(this));
+        token.safeTransferFrom(msg.sender, address(this), _amount);
+        uint256 _after = token.balanceOf(address(this));
+        _amount = _after.sub(_before); // Additional check for deflationary tokens
+        uint256 shares = 0;
+        if (totalSupply() == 0) {
+            shares = _amount;
+        } else {
+            shares = (_amount.mul(totalSupply())).div(_pool);
+        }
+        _mint(recipient, shares);
+    }
+
+    function _depositWithAuthorization(uint256 _amount, bytes32[] memory proof) internal virtual {
+        if (address(guestList) != address(0)) {
+            require(guestList.authorized(msg.sender, _amount, proof), "guest-list-authorization");
+        }
+        _deposit(_amount);
+    }
+
+    function _depositForWithAuthorization(address _recipient, uint256 _amount, bytes32[] memory proof) internal virtual {
+        if (address(guestList) != address(0)) {
+            require(guestList.authorized(msg.sender, _amount, proof), "guest-list-authorization");
+        }
+        _depositFor(_recipient, _amount);
+    }
+
+    // No rebalance implementation for lower fees and faster swaps
+    function _withdraw(uint256 _shares) internal virtual {
+        uint256 r = (balance().mul(_shares)).div(totalSupply());
+        _burn(msg.sender, _shares);
+
+        // Check balance
+        uint256 b = token.balanceOf(address(this));
+        if (b < r) {
+            uint256 _toWithdraw = r.sub(b);
+            IController(controller).withdraw(address(token), _toWithdraw);
+            uint256 _after = token.balanceOf(address(this));
+            uint256 _diff = _after.sub(b);
+            if (_diff < _toWithdraw) {
+                r = b.add(_diff);
+            }
+        }
+
+        token.safeTransfer(msg.sender, r);
+    }
+
+    function _lockForBlock(address account) internal {
+        blockLock[account] = block.number;
+    }
+
+    /// ===== ERC20 Overrides =====
+
+    /// @dev Add blockLock to transfers, users cannot transfer tokens in the same block as a deposit or withdrawal.
+    function transfer(address recipient, uint256 amount) public virtual override whenNotPaused returns (bool) {
+        _blockLocked();
+        return super.transfer(recipient, amount);
+    }
+
+    function transferFrom(
+        address sender,
+        address recipient,
+        uint256 amount
+    ) public virtual override whenNotPaused returns (bool) {
+        _blockLocked();
+        return super.transferFrom(sender, recipient, amount);
+    }
+}

--- a/contracts/_original/SettV4_cvxcrv.sol
+++ b/contracts/_original/SettV4_cvxcrv.sol
@@ -1,0 +1,1650 @@
+/**
+ *Submitted for verification at Etherscan.io on 2021-06-30
+*/
+
+// Sources flattened with hardhat v2.4.1 https://hardhat.org
+
+// File deps/@openzeppelin/contracts-upgradeable/token/ERC20/IERC20Upgradeable.sol
+
+// SPDX-License-Identifier: MIT
+
+pragma solidity ^0.6.0;
+
+/**
+ * @dev Interface of the ERC20 standard as defined in the EIP.
+ */
+interface IERC20Upgradeable {
+    /**
+     * @dev Returns the amount of tokens in existence.
+     */
+    function totalSupply() external view returns (uint256);
+
+    /**
+     * @dev Returns the amount of tokens owned by `account`.
+     */
+    function balanceOf(address account) external view returns (uint256);
+
+    /**
+     * @dev Moves `amount` tokens from the caller's account to `recipient`.
+     *
+     * Returns a boolean value indicating whether the operation succeeded.
+     *
+     * Emits a {Transfer} event.
+     */
+    function transfer(address recipient, uint256 amount) external returns (bool);
+
+    /**
+     * @dev Returns the remaining number of tokens that `spender` will be
+     * allowed to spend on behalf of `owner` through {transferFrom}. This is
+     * zero by default.
+     *
+     * This value changes when {approve} or {transferFrom} are called.
+     */
+    function allowance(address owner, address spender) external view returns (uint256);
+
+    /**
+     * @dev Sets `amount` as the allowance of `spender` over the caller's tokens.
+     *
+     * Returns a boolean value indicating whether the operation succeeded.
+     *
+     * IMPORTANT: Beware that changing an allowance with this method brings the risk
+     * that someone may use both the old and the new allowance by unfortunate
+     * transaction ordering. One possible solution to mitigate this race
+     * condition is to first reduce the spender's allowance to 0 and set the
+     * desired value afterwards:
+     * https://github.com/ethereum/EIPs/issues/20#issuecomment-263524729
+     *
+     * Emits an {Approval} event.
+     */
+    function approve(address spender, uint256 amount) external returns (bool);
+
+    /**
+     * @dev Moves `amount` tokens from `sender` to `recipient` using the
+     * allowance mechanism. `amount` is then deducted from the caller's
+     * allowance.
+     *
+     * Returns a boolean value indicating whether the operation succeeded.
+     *
+     * Emits a {Transfer} event.
+     */
+    function transferFrom(address sender, address recipient, uint256 amount) external returns (bool);
+
+    /**
+     * @dev Emitted when `value` tokens are moved from one account (`from`) to
+     * another (`to`).
+     *
+     * Note that `value` may be zero.
+     */
+    event Transfer(address indexed from, address indexed to, uint256 value);
+
+    /**
+     * @dev Emitted when the allowance of a `spender` for an `owner` is set by
+     * a call to {approve}. `value` is the new allowance.
+     */
+    event Approval(address indexed owner, address indexed spender, uint256 value);
+}
+
+
+// File deps/@openzeppelin/contracts-upgradeable/math/SafeMathUpgradeable.sol
+
+
+
+pragma solidity ^0.6.0;
+
+/**
+ * @dev Wrappers over Solidity's arithmetic operations with added overflow
+ * checks.
+ *
+ * Arithmetic operations in Solidity wrap on overflow. This can easily result
+ * in bugs, because programmers usually assume that an overflow raises an
+ * error, which is the standard behavior in high level programming languages.
+ * `SafeMath` restores this intuition by reverting the transaction when an
+ * operation overflows.
+ *
+ * Using this library instead of the unchecked operations eliminates an entire
+ * class of bugs, so it's recommended to use it always.
+ */
+library SafeMathUpgradeable {
+    /**
+     * @dev Returns the addition of two unsigned integers, reverting on
+     * overflow.
+     *
+     * Counterpart to Solidity's `+` operator.
+     *
+     * Requirements:
+     *
+     * - Addition cannot overflow.
+     */
+    function add(uint256 a, uint256 b) internal pure returns (uint256) {
+        uint256 c = a + b;
+        require(c >= a, "SafeMath: addition overflow");
+
+        return c;
+    }
+
+    /**
+     * @dev Returns the subtraction of two unsigned integers, reverting on
+     * overflow (when the result is negative).
+     *
+     * Counterpart to Solidity's `-` operator.
+     *
+     * Requirements:
+     *
+     * - Subtraction cannot overflow.
+     */
+    function sub(uint256 a, uint256 b) internal pure returns (uint256) {
+        return sub(a, b, "SafeMath: subtraction overflow");
+    }
+
+    /**
+     * @dev Returns the subtraction of two unsigned integers, reverting with custom message on
+     * overflow (when the result is negative).
+     *
+     * Counterpart to Solidity's `-` operator.
+     *
+     * Requirements:
+     *
+     * - Subtraction cannot overflow.
+     */
+    function sub(uint256 a, uint256 b, string memory errorMessage) internal pure returns (uint256) {
+        require(b <= a, errorMessage);
+        uint256 c = a - b;
+
+        return c;
+    }
+
+    /**
+     * @dev Returns the multiplication of two unsigned integers, reverting on
+     * overflow.
+     *
+     * Counterpart to Solidity's `*` operator.
+     *
+     * Requirements:
+     *
+     * - Multiplication cannot overflow.
+     */
+    function mul(uint256 a, uint256 b) internal pure returns (uint256) {
+        // Gas optimization: this is cheaper than requiring 'a' not being zero, but the
+        // benefit is lost if 'b' is also tested.
+        // See: https://github.com/OpenZeppelin/openzeppelin-contracts/pull/522
+        if (a == 0) {
+            return 0;
+        }
+
+        uint256 c = a * b;
+        require(c / a == b, "SafeMath: multiplication overflow");
+
+        return c;
+    }
+
+    /**
+     * @dev Returns the integer division of two unsigned integers. Reverts on
+     * division by zero. The result is rounded towards zero.
+     *
+     * Counterpart to Solidity's `/` operator. Note: this function uses a
+     * `revert` opcode (which leaves remaining gas untouched) while Solidity
+     * uses an invalid opcode to revert (consuming all remaining gas).
+     *
+     * Requirements:
+     *
+     * - The divisor cannot be zero.
+     */
+    function div(uint256 a, uint256 b) internal pure returns (uint256) {
+        return div(a, b, "SafeMath: division by zero");
+    }
+
+    /**
+     * @dev Returns the integer division of two unsigned integers. Reverts with custom message on
+     * division by zero. The result is rounded towards zero.
+     *
+     * Counterpart to Solidity's `/` operator. Note: this function uses a
+     * `revert` opcode (which leaves remaining gas untouched) while Solidity
+     * uses an invalid opcode to revert (consuming all remaining gas).
+     *
+     * Requirements:
+     *
+     * - The divisor cannot be zero.
+     */
+    function div(uint256 a, uint256 b, string memory errorMessage) internal pure returns (uint256) {
+        require(b > 0, errorMessage);
+        uint256 c = a / b;
+        // assert(a == b * c + a % b); // There is no case in which this doesn't hold
+
+        return c;
+    }
+
+    /**
+     * @dev Returns the remainder of dividing two unsigned integers. (unsigned integer modulo),
+     * Reverts when dividing by zero.
+     *
+     * Counterpart to Solidity's `%` operator. This function uses a `revert`
+     * opcode (which leaves remaining gas untouched) while Solidity uses an
+     * invalid opcode to revert (consuming all remaining gas).
+     *
+     * Requirements:
+     *
+     * - The divisor cannot be zero.
+     */
+    function mod(uint256 a, uint256 b) internal pure returns (uint256) {
+        return mod(a, b, "SafeMath: modulo by zero");
+    }
+
+    /**
+     * @dev Returns the remainder of dividing two unsigned integers. (unsigned integer modulo),
+     * Reverts with custom message when dividing by zero.
+     *
+     * Counterpart to Solidity's `%` operator. This function uses a `revert`
+     * opcode (which leaves remaining gas untouched) while Solidity uses an
+     * invalid opcode to revert (consuming all remaining gas).
+     *
+     * Requirements:
+     *
+     * - The divisor cannot be zero.
+     */
+    function mod(uint256 a, uint256 b, string memory errorMessage) internal pure returns (uint256) {
+        require(b != 0, errorMessage);
+        return a % b;
+    }
+}
+
+
+// File deps/@openzeppelin/contracts-upgradeable/utils/AddressUpgradeable.sol
+
+
+
+pragma solidity ^0.6.2;
+
+/**
+ * @dev Collection of functions related to the address type
+ */
+library AddressUpgradeable {
+    /**
+     * @dev Returns true if `account` is a contract.
+     *
+     * [IMPORTANT]
+     * ====
+     * It is unsafe to assume that an address for which this function returns
+     * false is an externally-owned account (EOA) and not a contract.
+     *
+     * Among others, `isContract` will return false for the following
+     * types of addresses:
+     *
+     *  - an externally-owned account
+     *  - a contract in construction
+     *  - an address where a contract will be created
+     *  - an address where a contract lived, but was destroyed
+     * ====
+     */
+    function isContract(address account) internal view returns (bool) {
+        // This method relies in extcodesize, which returns 0 for contracts in
+        // construction, since the code is only stored at the end of the
+        // constructor execution.
+
+        uint256 size;
+        // solhint-disable-next-line no-inline-assembly
+        assembly { size := extcodesize(account) }
+        return size > 0;
+    }
+
+    /**
+     * @dev Replacement for Solidity's `transfer`: sends `amount` wei to
+     * `recipient`, forwarding all available gas and reverting on errors.
+     *
+     * https://eips.ethereum.org/EIPS/eip-1884[EIP1884] increases the gas cost
+     * of certain opcodes, possibly making contracts go over the 2300 gas limit
+     * imposed by `transfer`, making them unable to receive funds via
+     * `transfer`. {sendValue} removes this limitation.
+     *
+     * https://diligence.consensys.net/posts/2019/09/stop-using-soliditys-transfer-now/[Learn more].
+     *
+     * IMPORTANT: because control is transferred to `recipient`, care must be
+     * taken to not create reentrancy vulnerabilities. Consider using
+     * {ReentrancyGuard} or the
+     * https://solidity.readthedocs.io/en/v0.5.11/security-considerations.html#use-the-checks-effects-interactions-pattern[checks-effects-interactions pattern].
+     */
+    function sendValue(address payable recipient, uint256 amount) internal {
+        require(address(this).balance >= amount, "Address: insufficient balance");
+
+        // solhint-disable-next-line avoid-low-level-calls, avoid-call-value
+        (bool success, ) = recipient.call{ value: amount }("");
+        require(success, "Address: unable to send value, recipient may have reverted");
+    }
+
+    /**
+     * @dev Performs a Solidity function call using a low level `call`. A
+     * plain`call` is an unsafe replacement for a function call: use this
+     * function instead.
+     *
+     * If `target` reverts with a revert reason, it is bubbled up by this
+     * function (like regular Solidity function calls).
+     *
+     * Returns the raw returned data. To convert to the expected return value,
+     * use https://solidity.readthedocs.io/en/latest/units-and-global-variables.html?highlight=abi.decode#abi-encoding-and-decoding-functions[`abi.decode`].
+     *
+     * Requirements:
+     *
+     * - `target` must be a contract.
+     * - calling `target` with `data` must not revert.
+     *
+     * _Available since v3.1._
+     */
+    function functionCall(address target, bytes memory data) internal returns (bytes memory) {
+      return functionCall(target, data, "Address: low-level call failed");
+    }
+
+    /**
+     * @dev Same as {xref-Address-functionCall-address-bytes-}[`functionCall`], but with
+     * `errorMessage` as a fallback revert reason when `target` reverts.
+     *
+     * _Available since v3.1._
+     */
+    function functionCall(address target, bytes memory data, string memory errorMessage) internal returns (bytes memory) {
+        return _functionCallWithValue(target, data, 0, errorMessage);
+    }
+
+    /**
+     * @dev Same as {xref-Address-functionCall-address-bytes-}[`functionCall`],
+     * but also transferring `value` wei to `target`.
+     *
+     * Requirements:
+     *
+     * - the calling contract must have an ETH balance of at least `value`.
+     * - the called Solidity function must be `payable`.
+     *
+     * _Available since v3.1._
+     */
+    function functionCallWithValue(address target, bytes memory data, uint256 value) internal returns (bytes memory) {
+        return functionCallWithValue(target, data, value, "Address: low-level call with value failed");
+    }
+
+    /**
+     * @dev Same as {xref-Address-functionCallWithValue-address-bytes-uint256-}[`functionCallWithValue`], but
+     * with `errorMessage` as a fallback revert reason when `target` reverts.
+     *
+     * _Available since v3.1._
+     */
+    function functionCallWithValue(address target, bytes memory data, uint256 value, string memory errorMessage) internal returns (bytes memory) {
+        require(address(this).balance >= value, "Address: insufficient balance for call");
+        return _functionCallWithValue(target, data, value, errorMessage);
+    }
+
+    function _functionCallWithValue(address target, bytes memory data, uint256 weiValue, string memory errorMessage) private returns (bytes memory) {
+        require(isContract(target), "Address: call to non-contract");
+
+        // solhint-disable-next-line avoid-low-level-calls
+        (bool success, bytes memory returndata) = target.call{ value: weiValue }(data);
+        if (success) {
+            return returndata;
+        } else {
+            // Look for revert reason and bubble it up if present
+            if (returndata.length > 0) {
+                // The easiest way to bubble the revert reason is using memory via assembly
+
+                // solhint-disable-next-line no-inline-assembly
+                assembly {
+                    let returndata_size := mload(returndata)
+                    revert(add(32, returndata), returndata_size)
+                }
+            } else {
+                revert(errorMessage);
+            }
+        }
+    }
+}
+
+
+// File deps/@openzeppelin/contracts-upgradeable/token/ERC20/SafeERC20Upgradeable.sol
+
+
+
+pragma solidity ^0.6.0;
+
+
+
+/**
+ * @title SafeERC20
+ * @dev Wrappers around ERC20 operations that throw on failure (when the token
+ * contract returns false). Tokens that return no value (and instead revert or
+ * throw on failure) are also supported, non-reverting calls are assumed to be
+ * successful.
+ * To use this library you can add a `using SafeERC20 for IERC20;` statement to your contract,
+ * which allows you to call the safe operations as `token.safeTransfer(...)`, etc.
+ */
+library SafeERC20Upgradeable {
+    using SafeMathUpgradeable for uint256;
+    using AddressUpgradeable for address;
+
+    function safeTransfer(IERC20Upgradeable token, address to, uint256 value) internal {
+        _callOptionalReturn(token, abi.encodeWithSelector(token.transfer.selector, to, value));
+    }
+
+    function safeTransferFrom(IERC20Upgradeable token, address from, address to, uint256 value) internal {
+        _callOptionalReturn(token, abi.encodeWithSelector(token.transferFrom.selector, from, to, value));
+    }
+
+    /**
+     * @dev Deprecated. This function has issues similar to the ones found in
+     * {IERC20-approve}, and its usage is discouraged.
+     *
+     * Whenever possible, use {safeIncreaseAllowance} and
+     * {safeDecreaseAllowance} instead.
+     */
+    function safeApprove(IERC20Upgradeable token, address spender, uint256 value) internal {
+        // safeApprove should only be called when setting an initial allowance,
+        // or when resetting it to zero. To increase and decrease it, use
+        // 'safeIncreaseAllowance' and 'safeDecreaseAllowance'
+        // solhint-disable-next-line max-line-length
+        require((value == 0) || (token.allowance(address(this), spender) == 0),
+            "SafeERC20: approve from non-zero to non-zero allowance"
+        );
+        _callOptionalReturn(token, abi.encodeWithSelector(token.approve.selector, spender, value));
+    }
+
+    function safeIncreaseAllowance(IERC20Upgradeable token, address spender, uint256 value) internal {
+        uint256 newAllowance = token.allowance(address(this), spender).add(value);
+        _callOptionalReturn(token, abi.encodeWithSelector(token.approve.selector, spender, newAllowance));
+    }
+
+    function safeDecreaseAllowance(IERC20Upgradeable token, address spender, uint256 value) internal {
+        uint256 newAllowance = token.allowance(address(this), spender).sub(value, "SafeERC20: decreased allowance below zero");
+        _callOptionalReturn(token, abi.encodeWithSelector(token.approve.selector, spender, newAllowance));
+    }
+
+    /**
+     * @dev Imitates a Solidity high-level call (i.e. a regular function call to a contract), relaxing the requirement
+     * on the return value: the return value is optional (but if data is returned, it must not be false).
+     * @param token The token targeted by the call.
+     * @param data The call data (encoded using abi.encode or one of its variants).
+     */
+    function _callOptionalReturn(IERC20Upgradeable token, bytes memory data) private {
+        // We need to perform a low level call here, to bypass Solidity's return data size checking mechanism, since
+        // we're implementing it ourselves. We use {Address.functionCall} to perform this call, which verifies that
+        // the target address contains contract code and also asserts for success in the low-level call.
+
+        bytes memory returndata = address(token).functionCall(data, "SafeERC20: low-level call failed");
+        if (returndata.length > 0) { // Return data is optional
+            // solhint-disable-next-line max-line-length
+            require(abi.decode(returndata, (bool)), "SafeERC20: ERC20 operation did not succeed");
+        }
+    }
+}
+
+
+// File deps/@openzeppelin/contracts-upgradeable/proxy/Initializable.sol
+
+
+
+pragma solidity >=0.4.24 <0.7.0;
+
+
+/**
+ * @dev This is a base contract to aid in writing upgradeable contracts, or any kind of contract that will be deployed
+ * behind a proxy. Since a proxied contract can't have a constructor, it's common to move constructor logic to an
+ * external initializer function, usually called `initialize`. It then becomes necessary to protect this initializer
+ * function so it can only be called once. The {initializer} modifier provided by this contract will have this effect.
+ * 
+ * TIP: To avoid leaving the proxy in an uninitialized state, the initializer function should be called as early as
+ * possible by providing the encoded function call as the `_data` argument to {UpgradeableProxy-constructor}.
+ * 
+ * CAUTION: When used with inheritance, manual care must be taken to not invoke a parent initializer twice, or to ensure
+ * that all initializers are idempotent. This is not verified automatically as constructors are by Solidity.
+ */
+abstract contract Initializable {
+
+    /**
+     * @dev Indicates that the contract has been initialized.
+     */
+    bool private _initialized;
+
+    /**
+     * @dev Indicates that the contract is in the process of being initialized.
+     */
+    bool private _initializing;
+
+    /**
+     * @dev Modifier to protect an initializer function from being invoked twice.
+     */
+    modifier initializer() {
+        require(_initializing || _isConstructor() || !_initialized, "Initializable: contract is already initialized");
+
+        bool isTopLevelCall = !_initializing;
+        if (isTopLevelCall) {
+            _initializing = true;
+            _initialized = true;
+        }
+
+        _;
+
+        if (isTopLevelCall) {
+            _initializing = false;
+        }
+    }
+
+    /// @dev Returns true if and only if the function is running in the constructor
+    function _isConstructor() private view returns (bool) {
+        // extcodesize checks the size of the code stored in an address, and
+        // address returns the current address. Since the code is still not
+        // deployed when running a constructor, any checks on its code size will
+        // yield zero, making it an effective way to detect if a contract is
+        // under construction or not.
+        address self = address(this);
+        uint256 cs;
+        // solhint-disable-next-line no-inline-assembly
+        assembly { cs := extcodesize(self) }
+        return cs == 0;
+    }
+}
+
+
+// File deps/@openzeppelin/contracts-upgradeable/GSN/ContextUpgradeable.sol
+
+
+
+pragma solidity ^0.6.0;
+
+/*
+ * @dev Provides information about the current execution context, including the
+ * sender of the transaction and its data. While these are generally available
+ * via msg.sender and msg.data, they should not be accessed in such a direct
+ * manner, since when dealing with GSN meta-transactions the account sending and
+ * paying for execution may not be the actual sender (as far as an application
+ * is concerned).
+ *
+ * This contract is only required for intermediate, library-like contracts.
+ */
+abstract contract ContextUpgradeable is Initializable {
+    function __Context_init() internal initializer {
+        __Context_init_unchained();
+    }
+
+    function __Context_init_unchained() internal initializer {
+    }
+    function _msgSender() internal view virtual returns (address payable) {
+        return msg.sender;
+    }
+
+    function _msgData() internal view virtual returns (bytes memory) {
+        this; // silence state mutability warning without generating bytecode - see https://github.com/ethereum/solidity/issues/2691
+        return msg.data;
+    }
+    uint256[50] private __gap;
+}
+
+
+// File deps/@openzeppelin/contracts-upgradeable/token/ERC20/ERC20Upgradeable.sol
+
+
+
+pragma solidity ^0.6.0;
+
+
+
+
+
+/**
+ * @dev Implementation of the {IERC20} interface.
+ *
+ * This implementation is agnostic to the way tokens are created. This means
+ * that a supply mechanism has to be added in a derived contract using {_mint}.
+ * For a generic mechanism see {ERC20PresetMinterPauser}.
+ *
+ * TIP: For a detailed writeup see our guide
+ * https://forum.zeppelin.solutions/t/how-to-implement-erc20-supply-mechanisms/226[How
+ * to implement supply mechanisms].
+ *
+ * We have followed general OpenZeppelin guidelines: functions revert instead
+ * of returning `false` on failure. This behavior is nonetheless conventional
+ * and does not conflict with the expectations of ERC20 applications.
+ *
+ * Additionally, an {Approval} event is emitted on calls to {transferFrom}.
+ * This allows applications to reconstruct the allowance for all accounts just
+ * by listening to said events. Other implementations of the EIP may not emit
+ * these events, as it isn't required by the specification.
+ *
+ * Finally, the non-standard {decreaseAllowance} and {increaseAllowance}
+ * functions have been added to mitigate the well-known issues around setting
+ * allowances. See {IERC20-approve}.
+ */
+contract ERC20Upgradeable is Initializable, ContextUpgradeable, IERC20Upgradeable {
+    using SafeMathUpgradeable for uint256;
+    using AddressUpgradeable for address;
+
+    mapping (address => uint256) private _balances;
+
+    mapping (address => mapping (address => uint256)) private _allowances;
+
+    uint256 private _totalSupply;
+
+    string private _name;
+    string private _symbol;
+    uint8 private _decimals;
+
+    /**
+     * @dev Sets the values for {name} and {symbol}, initializes {decimals} with
+     * a default value of 18.
+     *
+     * To select a different value for {decimals}, use {_setupDecimals}.
+     *
+     * All three of these values are immutable: they can only be set once during
+     * construction.
+     */
+    function __ERC20_init(string memory name, string memory symbol) internal initializer {
+        __Context_init_unchained();
+        __ERC20_init_unchained(name, symbol);
+    }
+
+    function __ERC20_init_unchained(string memory name, string memory symbol) internal initializer {
+        _name = name;
+        _symbol = symbol;
+        _decimals = 18;
+    }
+
+    /**
+     * @dev Returns the name of the token.
+     */
+    function name() public view returns (string memory) {
+        return _name;
+    }
+
+    /**
+     * @dev Returns the symbol of the token, usually a shorter version of the
+     * name.
+     */
+    function symbol() public view returns (string memory) {
+        return _symbol;
+    }
+
+    /**
+     * @dev Returns the number of decimals used to get its user representation.
+     * For example, if `decimals` equals `2`, a balance of `505` tokens should
+     * be displayed to a user as `5,05` (`505 / 10 ** 2`).
+     *
+     * Tokens usually opt for a value of 18, imitating the relationship between
+     * Ether and Wei. This is the value {ERC20} uses, unless {_setupDecimals} is
+     * called.
+     *
+     * NOTE: This information is only used for _display_ purposes: it in
+     * no way affects any of the arithmetic of the contract, including
+     * {IERC20-balanceOf} and {IERC20-transfer}.
+     */
+    function decimals() public view returns (uint8) {
+        return _decimals;
+    }
+
+    /**
+     * @dev See {IERC20-totalSupply}.
+     */
+    function totalSupply() public view override returns (uint256) {
+        return _totalSupply;
+    }
+
+    /**
+     * @dev See {IERC20-balanceOf}.
+     */
+    function balanceOf(address account) public view override returns (uint256) {
+        return _balances[account];
+    }
+
+    /**
+     * @dev See {IERC20-transfer}.
+     *
+     * Requirements:
+     *
+     * - `recipient` cannot be the zero address.
+     * - the caller must have a balance of at least `amount`.
+     */
+    function transfer(address recipient, uint256 amount) public virtual override returns (bool) {
+        _transfer(_msgSender(), recipient, amount);
+        return true;
+    }
+
+    /**
+     * @dev See {IERC20-allowance}.
+     */
+    function allowance(address owner, address spender) public view virtual override returns (uint256) {
+        return _allowances[owner][spender];
+    }
+
+    /**
+     * @dev See {IERC20-approve}.
+     *
+     * Requirements:
+     *
+     * - `spender` cannot be the zero address.
+     */
+    function approve(address spender, uint256 amount) public virtual override returns (bool) {
+        _approve(_msgSender(), spender, amount);
+        return true;
+    }
+
+    /**
+     * @dev See {IERC20-transferFrom}.
+     *
+     * Emits an {Approval} event indicating the updated allowance. This is not
+     * required by the EIP. See the note at the beginning of {ERC20};
+     *
+     * Requirements:
+     * - `sender` and `recipient` cannot be the zero address.
+     * - `sender` must have a balance of at least `amount`.
+     * - the caller must have allowance for ``sender``'s tokens of at least
+     * `amount`.
+     */
+    function transferFrom(address sender, address recipient, uint256 amount) public virtual override returns (bool) {
+        _transfer(sender, recipient, amount);
+        _approve(sender, _msgSender(), _allowances[sender][_msgSender()].sub(amount, "ERC20: transfer amount exceeds allowance"));
+        return true;
+    }
+
+    /**
+     * @dev Atomically increases the allowance granted to `spender` by the caller.
+     *
+     * This is an alternative to {approve} that can be used as a mitigation for
+     * problems described in {IERC20-approve}.
+     *
+     * Emits an {Approval} event indicating the updated allowance.
+     *
+     * Requirements:
+     *
+     * - `spender` cannot be the zero address.
+     */
+    function increaseAllowance(address spender, uint256 addedValue) public virtual returns (bool) {
+        _approve(_msgSender(), spender, _allowances[_msgSender()][spender].add(addedValue));
+        return true;
+    }
+
+    /**
+     * @dev Atomically decreases the allowance granted to `spender` by the caller.
+     *
+     * This is an alternative to {approve} that can be used as a mitigation for
+     * problems described in {IERC20-approve}.
+     *
+     * Emits an {Approval} event indicating the updated allowance.
+     *
+     * Requirements:
+     *
+     * - `spender` cannot be the zero address.
+     * - `spender` must have allowance for the caller of at least
+     * `subtractedValue`.
+     */
+    function decreaseAllowance(address spender, uint256 subtractedValue) public virtual returns (bool) {
+        _approve(_msgSender(), spender, _allowances[_msgSender()][spender].sub(subtractedValue, "ERC20: decreased allowance below zero"));
+        return true;
+    }
+
+    /**
+     * @dev Moves tokens `amount` from `sender` to `recipient`.
+     *
+     * This is internal function is equivalent to {transfer}, and can be used to
+     * e.g. implement automatic token fees, slashing mechanisms, etc.
+     *
+     * Emits a {Transfer} event.
+     *
+     * Requirements:
+     *
+     * - `sender` cannot be the zero address.
+     * - `recipient` cannot be the zero address.
+     * - `sender` must have a balance of at least `amount`.
+     */
+    function _transfer(address sender, address recipient, uint256 amount) internal virtual {
+        require(sender != address(0), "ERC20: transfer from the zero address");
+        require(recipient != address(0), "ERC20: transfer to the zero address");
+
+        _beforeTokenTransfer(sender, recipient, amount);
+
+        _balances[sender] = _balances[sender].sub(amount, "ERC20: transfer amount exceeds balance");
+        _balances[recipient] = _balances[recipient].add(amount);
+        emit Transfer(sender, recipient, amount);
+    }
+
+    /** @dev Creates `amount` tokens and assigns them to `account`, increasing
+     * the total supply.
+     *
+     * Emits a {Transfer} event with `from` set to the zero address.
+     *
+     * Requirements
+     *
+     * - `to` cannot be the zero address.
+     */
+    function _mint(address account, uint256 amount) internal virtual {
+        require(account != address(0), "ERC20: mint to the zero address");
+
+        _beforeTokenTransfer(address(0), account, amount);
+
+        _totalSupply = _totalSupply.add(amount);
+        _balances[account] = _balances[account].add(amount);
+        emit Transfer(address(0), account, amount);
+    }
+
+    /**
+     * @dev Destroys `amount` tokens from `account`, reducing the
+     * total supply.
+     *
+     * Emits a {Transfer} event with `to` set to the zero address.
+     *
+     * Requirements
+     *
+     * - `account` cannot be the zero address.
+     * - `account` must have at least `amount` tokens.
+     */
+    function _burn(address account, uint256 amount) internal virtual {
+        require(account != address(0), "ERC20: burn from the zero address");
+
+        _beforeTokenTransfer(account, address(0), amount);
+
+        _balances[account] = _balances[account].sub(amount, "ERC20: burn amount exceeds balance");
+        _totalSupply = _totalSupply.sub(amount);
+        emit Transfer(account, address(0), amount);
+    }
+
+    /**
+     * @dev Sets `amount` as the allowance of `spender` over the `owner` s tokens.
+     *
+     * This internal function is equivalent to `approve`, and can be used to
+     * e.g. set automatic allowances for certain subsystems, etc.
+     *
+     * Emits an {Approval} event.
+     *
+     * Requirements:
+     *
+     * - `owner` cannot be the zero address.
+     * - `spender` cannot be the zero address.
+     */
+    function _approve(address owner, address spender, uint256 amount) internal virtual {
+        require(owner != address(0), "ERC20: approve from the zero address");
+        require(spender != address(0), "ERC20: approve to the zero address");
+
+        _allowances[owner][spender] = amount;
+        emit Approval(owner, spender, amount);
+    }
+
+    /**
+     * @dev Sets {decimals} to a value other than the default one of 18.
+     *
+     * WARNING: This function should only be called from the constructor. Most
+     * applications that interact with token contracts will not expect
+     * {decimals} to ever change, and may work incorrectly if it does.
+     */
+    function _setupDecimals(uint8 decimals_) internal {
+        _decimals = decimals_;
+    }
+
+    /**
+     * @dev Hook that is called before any transfer of tokens. This includes
+     * minting and burning.
+     *
+     * Calling conditions:
+     *
+     * - when `from` and `to` are both non-zero, `amount` of ``from``'s tokens
+     * will be to transferred to `to`.
+     * - when `from` is zero, `amount` tokens will be minted for `to`.
+     * - when `to` is zero, `amount` of ``from``'s tokens will be burned.
+     * - `from` and `to` are never both zero.
+     *
+     * To learn more about hooks, head to xref:ROOT:extending-contracts.adoc#using-hooks[Using Hooks].
+     */
+    function _beforeTokenTransfer(address from, address to, uint256 amount) internal virtual { }
+    uint256[44] private __gap;
+}
+
+
+// File deps/@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol
+
+
+
+pragma solidity ^0.6.0;
+
+
+/**
+ * @dev Contract module which provides a basic access control mechanism, where
+ * there is an account (an owner) that can be granted exclusive access to
+ * specific functions.
+ *
+ * By default, the owner account will be the one that deploys the contract. This
+ * can later be changed with {transferOwnership}.
+ *
+ * This module is used through inheritance. It will make available the modifier
+ * `onlyOwner`, which can be applied to your functions to restrict their use to
+ * the owner.
+ */
+contract OwnableUpgradeable is Initializable, ContextUpgradeable {
+    address private _owner;
+
+    event OwnershipTransferred(address indexed previousOwner, address indexed newOwner);
+
+    /**
+     * @dev Initializes the contract setting the deployer as the initial owner.
+     */
+    function __Ownable_init() internal initializer {
+        __Context_init_unchained();
+        __Ownable_init_unchained();
+    }
+
+    function __Ownable_init_unchained() internal initializer {
+        address msgSender = _msgSender();
+        _owner = msgSender;
+        emit OwnershipTransferred(address(0), msgSender);
+    }
+
+    /**
+     * @dev Returns the address of the current owner.
+     */
+    function owner() public view returns (address) {
+        return _owner;
+    }
+
+    /**
+     * @dev Throws if called by any account other than the owner.
+     */
+    modifier onlyOwner() {
+        require(_owner == _msgSender(), "Ownable: caller is not the owner");
+        _;
+    }
+
+    /**
+     * @dev Leaves the contract without owner. It will not be possible to call
+     * `onlyOwner` functions anymore. Can only be called by the current owner.
+     *
+     * NOTE: Renouncing ownership will leave the contract without an owner,
+     * thereby removing any functionality that is only available to the owner.
+     */
+    function renounceOwnership() public virtual onlyOwner {
+        emit OwnershipTransferred(_owner, address(0));
+        _owner = address(0);
+    }
+
+    /**
+     * @dev Transfers ownership of the contract to a new account (`newOwner`).
+     * Can only be called by the current owner.
+     */
+    function transferOwnership(address newOwner) public virtual onlyOwner {
+        require(newOwner != address(0), "Ownable: new owner is the zero address");
+        emit OwnershipTransferred(_owner, newOwner);
+        _owner = newOwner;
+    }
+    uint256[49] private __gap;
+}
+
+
+// File deps/@openzeppelin/contracts-upgradeable/utils/PausableUpgradeable.sol
+
+
+
+pragma solidity ^0.6.0;
+
+
+/**
+ * @dev Contract module which allows children to implement an emergency stop
+ * mechanism that can be triggered by an authorized account.
+ *
+ * This module is used through inheritance. It will make available the
+ * modifiers `whenNotPaused` and `whenPaused`, which can be applied to
+ * the functions of your contract. Note that they will not be pausable by
+ * simply including this module, only once the modifiers are put in place.
+ */
+contract PausableUpgradeable is Initializable, ContextUpgradeable {
+    /**
+     * @dev Emitted when the pause is triggered by `account`.
+     */
+    event Paused(address account);
+
+    /**
+     * @dev Emitted when the pause is lifted by `account`.
+     */
+    event Unpaused(address account);
+
+    bool private _paused;
+
+    /**
+     * @dev Initializes the contract in unpaused state.
+     */
+    function __Pausable_init() internal initializer {
+        __Context_init_unchained();
+        __Pausable_init_unchained();
+    }
+
+    function __Pausable_init_unchained() internal initializer {
+        _paused = false;
+    }
+
+    /**
+     * @dev Returns true if the contract is paused, and false otherwise.
+     */
+    function paused() public view returns (bool) {
+        return _paused;
+    }
+
+    /**
+     * @dev Modifier to make a function callable only when the contract is not paused.
+     *
+     * Requirements:
+     *
+     * - The contract must not be paused.
+     */
+    modifier whenNotPaused() {
+        require(!_paused, "Pausable: paused");
+        _;
+    }
+
+    /**
+     * @dev Modifier to make a function callable only when the contract is paused.
+     *
+     * Requirements:
+     *
+     * - The contract must be paused.
+     */
+    modifier whenPaused() {
+        require(_paused, "Pausable: not paused");
+        _;
+    }
+
+    /**
+     * @dev Triggers stopped state.
+     *
+     * Requirements:
+     *
+     * - The contract must not be paused.
+     */
+    function _pause() internal virtual whenNotPaused {
+        _paused = true;
+        emit Paused(_msgSender());
+    }
+
+    /**
+     * @dev Returns to normal state.
+     *
+     * Requirements:
+     *
+     * - The contract must be paused.
+     */
+    function _unpause() internal virtual whenPaused {
+        _paused = false;
+        emit Unpaused(_msgSender());
+    }
+    uint256[49] private __gap;
+}
+
+
+// File interfaces/badger/IController.sol
+
+
+pragma solidity >=0.5.0 <0.8.0;
+
+interface IController {
+    function withdraw(address, uint256) external;
+
+    function withdrawAll(address) external;
+
+    function strategies(address) external view returns (address);
+
+    function approvedStrategies(address, address) external view returns (address);
+
+    function balanceOf(address) external view returns (uint256);
+
+    function earn(address, uint256) external;
+
+    function approveStrategy(address, address) external;
+
+    function setStrategy(address, address) external;
+
+    function setVault(address, address) external;
+
+    function want(address) external view returns (address);
+
+    function rewards() external view returns (address);
+
+    function vaults(address) external view returns (address);
+}
+
+
+// File interfaces/erc20/IERC20Detailed.sol
+
+
+
+pragma solidity ^0.6.0;
+
+/**
+ * @dev Interface of the ERC20 standard as defined in the EIP.
+ */
+interface IERC20Detailed {
+    /**
+     * @dev Returns the amount of tokens in existence.
+     */
+    function totalSupply() external view returns (uint256);
+
+    function name() external view returns (string memory);
+    function symbol() external view returns (string memory);
+
+    /**
+     * @dev Returns the amount of tokens owned by `account`.
+     */
+    function balanceOf(address account) external view returns (uint256);
+
+    /**
+     * @dev Moves `amount` tokens from the caller's account to `recipient`.
+     *
+     * Returns a boolean value indicating whether the operation succeeded.
+     *
+     * Emits a {Transfer} event.
+     */
+    function transfer(address recipient, uint256 amount) external returns (bool);
+
+    /**
+     * @dev Returns the remaining number of tokens that `spender` will be
+     * allowed to spend on behalf of `owner` through {transferFrom}. This is
+     * zero by default.
+     *
+     * This value changes when {approve} or {transferFrom} are called.
+     */
+    function allowance(address owner, address spender) external view returns (uint256);
+
+    /**
+     * @dev Sets `amount` as the allowance of `spender` over the caller's tokens.
+     *
+     * Returns a boolean value indicating whether the operation succeeded.
+     *
+     * IMPORTANT: Beware that changing an allowance with this method brings the risk
+     * that someone may use both the old and the new allowance by unfortunate
+     * transaction ordering. One possible solution to mitigate this race
+     * condition is to first reduce the spender's allowance to 0 and set the
+     * desired value afterwards:
+     * https://github.com/ethereum/EIPs/issues/20#issuecomment-263524729
+     *
+     * Emits an {Approval} event.
+     */
+    function approve(address spender, uint256 amount) external returns (bool);
+
+    /**
+     * @dev Moves `amount` tokens from `sender` to `recipient` using the
+     * allowance mechanism. `amount` is then deducted from the caller's
+     * allowance.
+     *
+     * Returns a boolean value indicating whether the operation succeeded.
+     *
+     * Emits a {Transfer} event.
+     */
+    function transferFrom(address sender, address recipient, uint256 amount) external returns (bool);
+
+    /**
+     * @dev Emitted when `value` tokens are moved from one account (`from`) to
+     * another (`to`).
+     *
+     * Note that `value` may be zero.
+     */
+    event Transfer(address indexed from, address indexed to, uint256 value);
+
+    /**
+     * @dev Emitted when the allowance of a `spender` for an `owner` is set by
+     * a call to {approve}. `value` is the new allowance.
+     */
+    event Approval(address indexed owner, address indexed spender, uint256 value);
+}
+
+
+// File contracts/badger-sett/SettAccessControl.sol
+
+
+pragma solidity ^0.6.11;
+
+/*
+    Common base for permissioned roles throughout Sett ecosystem
+*/
+contract SettAccessControl is Initializable {
+    address public governance;
+    address public strategist;
+    address public keeper;
+
+    // ===== MODIFIERS =====
+    function _onlyGovernance() internal view {
+        require(msg.sender == governance, "onlyGovernance");
+    }
+
+    function _onlyGovernanceOrStrategist() internal view {
+        require(msg.sender == strategist || msg.sender == governance, "onlyGovernanceOrStrategist");
+    }
+
+    function _onlyAuthorizedActors() internal view {
+        require(msg.sender == keeper || msg.sender == governance, "onlyAuthorizedActors");
+    }
+
+    // ===== PERMISSIONED ACTIONS =====
+
+    /// @notice Change strategist address
+    /// @notice Can only be changed by governance itself
+    function setStrategist(address _strategist) external {
+        _onlyGovernance();
+        strategist = _strategist;
+    }
+
+    /// @notice Change keeper address
+    /// @notice Can only be changed by governance itself
+    function setKeeper(address _keeper) external {
+        _onlyGovernance();
+        keeper = _keeper;
+    }
+
+    /// @notice Change governance address
+    /// @notice Can only be changed by governance itself
+    function setGovernance(address _governance) public {
+        _onlyGovernance();
+        governance = _governance;
+    }
+
+    uint256[50] private __gap;
+}
+
+
+// File contracts/badger-sett/SettAccessControlDefended.sol
+
+
+pragma solidity ^0.6.11;
+
+/*
+    Add ability to prevent unwanted contract access to Sett permissions
+*/
+contract SettAccessControlDefended is SettAccessControl {
+    mapping (address => bool) public approved;
+
+    function approveContractAccess(address account) external {
+        _onlyGovernance();
+        approved[account] = true;
+    }
+
+    function revokeContractAccess(address account) external {
+        _onlyGovernance();
+        approved[account] = false;
+    }
+
+    function _defend() internal view returns (bool) {
+        require(approved[msg.sender] || msg.sender == tx.origin, "Access denied for caller");
+    }
+    uint256[50] private __gap;
+}
+
+
+// File interfaces/yearn/BadgerGuestlistApi.sol
+
+
+pragma solidity >=0.6.0 <0.7.0;
+
+interface BadgerGuestListAPI {
+    function authorized(address guest, uint256 amount, bytes32[] calldata merkleProof) external view returns (bool);
+    function setGuests(address[] calldata _guests, bool[] calldata _invited) external;
+}
+
+
+// File contracts/badger-sett/SettV4.sol
+
+
+
+pragma solidity ^0.6.11;
+
+
+
+
+
+
+
+
+
+
+/* 
+    Source: https://github.com/iearn-finance/yearn-protocol/blob/develop/contracts/vaults/yVault.sol
+    
+    Changelog:
+
+    V1.1
+    * Strategist no longer has special function calling permissions
+    * Version function added to contract
+    * All write functions, with the exception of transfer, are pausable
+    * Keeper or governance can pause
+    * Only governance can unpause
+
+    V1.2
+    * Transfer functions are now pausable along with all other non-permissioned write functions
+    * All permissioned write functions, with the exception of pause() & unpause(), are pausable as well
+
+    V1.3
+    * Add guest list functionality
+    * All deposits can be optionally gated by external guestList approval logic on set guestList contract
+
+    V1.4
+    * Add depositFor() to deposit on the half of other users. That user will then be blockLocked.
+*/
+
+contract SettV4 is ERC20Upgradeable, SettAccessControlDefended, PausableUpgradeable {
+    using SafeERC20Upgradeable for IERC20Upgradeable;
+    using AddressUpgradeable for address;
+    using SafeMathUpgradeable for uint256;
+
+    IERC20Upgradeable public token;
+
+    uint256 public min;
+    uint256 public constant max = 10000;
+
+    address public controller;
+
+    mapping(address => uint256) public blockLock;
+
+    string internal constant _defaultNamePrefix = "Badger Sett ";
+    string internal constant _symbolSymbolPrefix = "b";
+
+    address public guardian;
+
+    BadgerGuestListAPI public guestList;
+
+    event FullPricePerShareUpdated(uint256 value, uint256 indexed timestamp, uint256 indexed blockNumber);
+
+    function initialize(
+        address _token,
+        address _controller,
+        address _governance,
+        address _keeper,
+        address _guardian,
+        bool _overrideTokenName,
+        string memory _namePrefix,
+        string memory _symbolPrefix
+    ) public initializer whenNotPaused {
+        IERC20Detailed namedToken = IERC20Detailed(_token);
+        string memory tokenName = namedToken.name();
+        string memory tokenSymbol = namedToken.symbol();
+
+        string memory name;
+        string memory symbol;
+
+        if (_overrideTokenName) {
+            name = string(abi.encodePacked(_namePrefix, tokenName));
+            symbol = string(abi.encodePacked(_symbolPrefix, tokenSymbol));
+        } else {
+            name = string(abi.encodePacked(_defaultNamePrefix, tokenName));
+            symbol = string(abi.encodePacked(_symbolSymbolPrefix, tokenSymbol));
+        }
+
+        __ERC20_init(name, symbol);
+
+        token = IERC20Upgradeable(_token);
+        governance = _governance;
+        strategist = address(0);
+        keeper = _keeper;
+        controller = _controller;
+        guardian = _guardian;
+
+        min = 9500;
+
+        emit FullPricePerShareUpdated(getPricePerFullShare(), now, block.number);
+
+        // Paused on launch
+        _pause();
+    }
+
+    /// ===== Modifiers =====
+
+    function _onlyController() internal view {
+        require(msg.sender == controller, "onlyController");
+    }
+
+    function _onlyAuthorizedPausers() internal view {
+        require(msg.sender == guardian || msg.sender == governance, "onlyPausers");
+    }
+
+    function _blockLocked() internal view {
+        require(blockLock[msg.sender] < block.number, "blockLocked");
+    }
+
+    /// ===== View Functions =====
+
+    function version() public view returns (string memory) {
+        return "1.4";
+    }
+
+    function getPricePerFullShare() public virtual view returns (uint256) {
+        if (totalSupply() == 0) {
+            return 1e18;
+        }
+        return balance().mul(1e18).div(totalSupply());
+    }
+
+    /// @notice Return the total balance of the underlying token within the system
+    /// @notice Sums the balance in the Sett, the Controller, and the Strategy
+    function balance() public virtual view returns (uint256) {
+        return token.balanceOf(address(this)).add(IController(controller).balanceOf(address(token)));
+    }
+
+    /// @notice Defines how much of the Setts' underlying can be borrowed by the Strategy for use
+    /// @notice Custom logic in here for how much the vault allows to be borrowed
+    /// @notice Sets minimum required on-hand to keep small withdrawals cheap
+    function available() public virtual view returns (uint256) {
+        return token.balanceOf(address(this)).mul(min).div(max);
+    }
+
+    /// ===== Public Actions =====
+
+    /// @notice Deposit assets into the Sett, and return corresponding shares to the user
+    /// @notice Only callable by EOA accounts that pass the _defend() check
+    function deposit(uint256 _amount) public whenNotPaused {
+        _defend();
+        _blockLocked();
+
+        _lockForBlock(msg.sender);
+        _depositWithAuthorization(_amount, new bytes32[](0));
+    }
+
+    /// @notice Deposit variant with proof for merkle guest list
+    function deposit(uint256 _amount, bytes32[] memory proof) public whenNotPaused {
+        _defend();
+        _blockLocked();
+
+        _lockForBlock(msg.sender);
+        _depositWithAuthorization(_amount, proof);
+    }
+
+    /// @notice Convenience function: Deposit entire balance of asset into the Sett, and return corresponding shares to the user
+    /// @notice Only callable by EOA accounts that pass the _defend() check
+    function depositAll() external whenNotPaused {
+        _defend();
+        _blockLocked();
+
+        _lockForBlock(msg.sender);
+        _depositWithAuthorization(token.balanceOf(msg.sender), new bytes32[](0));
+    }
+
+    /// @notice DepositAll variant with proof for merkle guest list
+    function depositAll(bytes32[] memory proof) external whenNotPaused {
+        _defend();
+        _blockLocked();
+
+        _lockForBlock(msg.sender);
+        _depositWithAuthorization(token.balanceOf(msg.sender), proof);
+    }
+
+    /// @notice Deposit assets into the Sett, and return corresponding shares to the user
+    /// @notice Only callable by EOA accounts that pass the _defend() check
+    function depositFor(address _recipient, uint256 _amount) public whenNotPaused {
+        _defend();
+        _blockLocked();
+
+        _lockForBlock(_recipient);
+        _depositForWithAuthorization(_recipient, _amount, new bytes32[](0));
+    }
+
+    /// @notice Deposit variant with proof for merkle guest list
+    function depositFor(
+        address _recipient,
+        uint256 _amount,
+        bytes32[] memory proof
+    ) public whenNotPaused {
+        _defend();
+        _blockLocked();
+
+        _lockForBlock(_recipient);
+        _depositForWithAuthorization(_recipient, _amount, proof);
+    }
+
+    /// @notice No rebalance implementation for lower fees and faster swaps
+    function withdraw(uint256 _shares) public whenNotPaused {
+        _defend();
+        _blockLocked();
+
+        _lockForBlock(msg.sender);
+        _withdraw(_shares);
+    }
+
+    /// @notice Convenience function: Withdraw all shares of the sender
+    function withdrawAll() external whenNotPaused {
+        _defend();
+        _blockLocked();
+
+        _lockForBlock(msg.sender);
+        _withdraw(balanceOf(msg.sender));
+    }
+
+    /// ===== Permissioned Actions: Governance =====
+
+    function setGuestList(address _guestList) external whenNotPaused {
+        _onlyGovernance();
+        guestList = BadgerGuestListAPI(_guestList);
+    }
+
+    /// @notice Set minimum threshold of underlying that must be deposited in strategy
+    /// @notice Can only be changed by governance
+    function setMin(uint256 _min) external whenNotPaused {
+        _onlyGovernance();
+        min = _min;
+    }
+
+    /// @notice Change controller address
+    /// @notice Can only be changed by governance
+    function setController(address _controller) public whenNotPaused {
+        _onlyGovernance();
+        controller = _controller;
+    }
+
+    /// @notice Change guardian address
+    /// @notice Can only be changed by governance
+    function setGuardian(address _guardian) external whenNotPaused {
+        _onlyGovernance();
+        guardian = _guardian;
+    }
+
+    /// ===== Permissioned Actions: Controller =====
+
+    /// @notice Used to swap any borrowed reserve over the debt limit to liquidate to 'token'
+    /// @notice Only controller can trigger harvests
+    function harvest(address reserve, uint256 amount) external whenNotPaused {
+        _onlyController();
+        require(reserve != address(token), "token");
+        IERC20Upgradeable(reserve).safeTransfer(controller, amount);
+    }
+
+    /// ===== Permissioned Functions: Trusted Actors =====
+
+    /// @notice Transfer the underlying available to be claimed to the controller
+    /// @notice The controller will deposit into the Strategy for yield-generating activities
+    /// @notice Permissionless operation
+    function earn() public whenNotPaused {
+        _onlyAuthorizedActors();
+
+        uint256 _bal = available();
+        token.safeTransfer(controller, _bal);
+        IController(controller).earn(address(token), _bal);
+    }
+
+    /// @dev Emit event tracking current full price per share
+    /// @dev Provides a pure on-chain way of approximating APY
+    function trackFullPricePerShare() external whenNotPaused {
+        _onlyAuthorizedActors();
+        emit FullPricePerShareUpdated(getPricePerFullShare(), now, block.number);
+    }
+
+    function pause() external {
+        _onlyAuthorizedPausers();
+        _pause();
+    }
+
+    function unpause() external {
+        _onlyGovernance();
+        _unpause();
+    }
+
+    /// ===== Internal Implementations =====
+
+    /// @dev Calculate the number of shares to issue for a given deposit
+    /// @dev This is based on the realized value of underlying assets between Sett & associated Strategy
+    // @dev deposit for msg.sender
+    function _deposit(uint256 _amount) internal {
+        _depositFor(msg.sender, _amount);
+    }
+
+    function _depositFor(address recipient, uint256 _amount) internal virtual {
+        uint256 _pool = balance();
+        uint256 _before = token.balanceOf(address(this));
+        token.safeTransferFrom(msg.sender, address(this), _amount);
+        uint256 _after = token.balanceOf(address(this));
+        _amount = _after.sub(_before); // Additional check for deflationary tokens
+        uint256 shares = 0;
+        if (totalSupply() == 0) {
+            shares = _amount;
+        } else {
+            shares = (_amount.mul(totalSupply())).div(_pool);
+        }
+        _mint(recipient, shares);
+    }
+
+    function _depositWithAuthorization(uint256 _amount, bytes32[] memory proof) internal virtual {
+        if (address(guestList) != address(0)) {
+            require(guestList.authorized(msg.sender, _amount, proof), "guest-list-authorization");
+        }
+        _deposit(_amount);
+    }
+
+    function _depositForWithAuthorization(
+        address _recipient,
+        uint256 _amount,
+        bytes32[] memory proof
+    ) internal virtual {
+        if (address(guestList) != address(0)) {
+            require(guestList.authorized(_recipient, _amount, proof), "guest-list-authorization");
+        }
+        _depositFor(_recipient, _amount);
+    }
+
+    // No rebalance implementation for lower fees and faster swaps
+    function _withdraw(uint256 _shares) internal virtual {
+        uint256 r = (balance().mul(_shares)).div(totalSupply());
+        _burn(msg.sender, _shares);
+
+        // Check balance
+        uint256 b = token.balanceOf(address(this));
+        if (b < r) {
+            uint256 _toWithdraw = r.sub(b);
+            IController(controller).withdraw(address(token), _toWithdraw);
+            uint256 _after = token.balanceOf(address(this));
+            uint256 _diff = _after.sub(b);
+            if (_diff < _toWithdraw) {
+                r = b.add(_diff);
+            }
+        }
+
+        token.safeTransfer(msg.sender, r);
+    }
+
+    function _lockForBlock(address account) internal {
+        blockLock[account] = block.number;
+    }
+
+    /// ===== ERC20 Overrides =====
+
+    /// @dev Add blockLock to transfers, users cannot transfer tokens in the same block as a deposit or withdrawal.
+    function transfer(address recipient, uint256 amount) public virtual override whenNotPaused returns (bool) {
+        _blockLocked();
+        return super.transfer(recipient, amount);
+    }
+
+    function transferFrom(
+        address sender,
+        address recipient,
+        uint256 amount
+    ) public virtual override whenNotPaused returns (bool) {
+        _blockLocked();
+        return super.transferFrom(sender, recipient, amount);
+    }
+}

--- a/interfaces/IGac.sol
+++ b/interfaces/IGac.sol
@@ -6,6 +6,7 @@ interface IGac {
     function DEV_MULTISIG() external view returns (address);
     function paused() external view returns (bool);
     function transferFromDisabled() external view returns (bool);
+    function isBlacklisted(address account) external view returns (bool);
 
     function unpause() external;
     function enableTransferFrom() external;

--- a/interfaces/IGac.sol
+++ b/interfaces/IGac.sol
@@ -4,10 +4,18 @@ pragma solidity ^0.6.11;
 
 interface IGac {
     function DEV_MULTISIG() external view returns (address);
+
+    function BLACKLISTED_ROLE() external view returns (bytes32);
+
     function paused() external view returns (bool);
+
     function transferFromDisabled() external view returns (bool);
+
     function isBlacklisted(address account) external view returns (bool);
 
     function unpause() external;
+
     function enableTransferFrom() external;
+
+    function grantRole(bytes32 role, address account) external;
 }

--- a/tests/test_gac.py
+++ b/tests/test_gac.py
@@ -1,0 +1,321 @@
+import brownie
+from brownie import *
+import pytest
+
+"""
+Test for integration of GAC pausing functionalities to Setts
+"""
+
+MAX_UINT256 = 2 ** 256 - 1
+
+LIST_OF_EXPLOITERS = [
+    "0xa33B95ea28542Ada32117B60E4F5B4cB7D1Fc19B",
+    "0x4fbf7701b3078B5bed6F3e64dF3AE09650eE7DE5",
+    "0x1B1b391D1026A4e3fB7F082ede068B25358a61F2",
+    "0xEcD91D07b1b6B81d24F2a469de8e47E3fe3050fd",
+    "0x691dA2826AC32BBF2a4b5d6f2A07CE07552A9A8E",
+    "0x91d65D67FC573605bCb0b5E39F9ef6E18aFA1586",
+    "0x0B88A083dc7b8aC2A84eBA02E4acb2e5f2d3063C",
+    "0x2eF1b70F195fd0432f9C36fB2eF7C99629B0398c",
+    "0xbbfD8041EbDE22A7f3e19600B4bab4925Cc97f7D",
+    "0xe06eD65924dB2e7b4c83E07079A424C8a36701E5",
+]
+
+SETT_ADDRESSES_V1 = [
+    "0xd04c48A53c111300aD41190D63681ed3dAd998eC",
+    "0x6dEf55d2e18486B9dDfaA075bc4e4EE0B28c1545",
+]
+
+SETT_ADDRESSES_V1_1 = [
+    "0x1862A18181346EBd9EdAf800804f89190DeF24a5",
+    "0x88128580ACdD9c04Ce47AFcE196875747bF2A9f6",
+]
+
+SETT_ADDRESSES_V4 = [
+    "0x2B5455aac8d64C14786c3a29858E43b5945819C0",
+    "0xaE96fF08771a109dc6650a1BdCa62F2d558E40af",
+    "0x27E98fC7d05f54E544d16F58C194C2D7ba71e3B5",
+    "0x599D92B453C010b1050d31C364f6ee17E819f193",
+    "0x26B8efa69603537AC8ab55768b6740b67664D518",
+    "0xfd05D3C7fe2924020620A8bE4961bBaA747e6305",
+    "0x937B8E917d0F36eDEBBA8E459C5FB16F3b315551",
+]
+
+
+@pytest.mark.parametrize(
+    "settAddress",
+    SETT_ADDRESSES_V1 + SETT_ADDRESSES_V1_1 + SETT_ADDRESSES_V4,
+)
+def test_gac_pause(settAddress, proxy_admin, proxy_admin_gov, bve_cvx, bcvx_crv):
+
+    # UPGRADE block
+    if settAddress in SETT_ADDRESSES_V1:
+        vault_proxy = SettV1h.at(settAddress)
+        governance = accounts.at(vault_proxy.governance(), force=True)
+
+        new_vault_logic = SettV1h.deploy({"from": governance})
+
+    elif settAddress in SETT_ADDRESSES_V1_1:
+        vault_proxy = SettV1_1h.at(settAddress)
+        governance = accounts.at(vault_proxy.governance(), force=True)
+
+        new_vault_logic = SettV1_1h.deploy({"from": governance})
+    else:
+        vault_proxy = SettV4h.at(settAddress)
+        governance = accounts.at(vault_proxy.governance(), force=True)
+
+        new_vault_logic = SettV4h.deploy({"from": governance})
+
+    if bve_cvx.paused() and not settAddress == bve_cvx.address:
+        bve_gov = accounts.at(bve_cvx.governance(), force=True)
+        bve_cvx.unpause({"from": bve_gov})
+
+    if bcvx_crv.paused() and not settAddress == bcvx_crv.address:
+        bcvx_crv_gov = accounts.at(bcvx_crv.governance(), force=True)
+        bcvx_crv.unpause({"from": bcvx_crv_gov})
+
+    # Execute upgrade
+    proxy_admin.upgrade(vault_proxy, new_vault_logic, {"from": proxy_admin_gov})
+
+    ## You can unpause if GAC is paused or unpaused (SettV1 can't be paused directly)
+    try:
+        if vault_proxy.paused() == True:
+            vault_proxy.unpause({"from": governance})
+            assert vault_proxy.paused() == False
+    except:
+        pass
+
+    ## GAC Pause Block
+
+    ## Get GAC actors
+    gac = interface.IGac(vault_proxy.GAC())
+    gac_gov = accounts.at(gac.DEV_MULTISIG(), force=True)
+    gac_guardian = accounts.at(gac.WAR_ROOM_ACL(), force=True)
+    assert gac.paused() == True
+
+    # Focused on testing pausing functionality
+    if gac.transferFromDisabled() == True:
+        gac.enableTransferFrom({"from": gac_gov})
+
+    # With the vault unpaused and GAC paused test all operations
+    controller = interface.IController(vault_proxy.controller())
+    strat = interface.IStrategy(controller.strategies(vault_proxy.token()))
+    strat_gov = accounts.at(strat.governance(), force=True)
+    if strat.paused():
+        strat.unpause({"from": strat_gov})
+
+    # Unpausing globally
+    gac.unpause({"from": gac_gov})
+    assert gac.paused() == False
+
+    # Transfer funds from exploiters to user
+    user = accounts[3]
+    for exploiter_address in LIST_OF_EXPLOITERS:
+        if vault_proxy.balanceOf(exploiter_address) > 0:
+            exploiter = accounts.at(exploiter_address, force=True)
+            vault_proxy.transfer(
+                user, vault_proxy.balanceOf(exploiter_address), {"from": exploiter}
+            )
+    assert vault_proxy.balanceOf(user) > 0
+
+    # Pausing globally from Guardian
+    gac.pause({"from": gac_guardian})
+    assert gac.paused() == True
+
+    # Functions should revert due to global pause
+    with brownie.reverts("Pausable: GAC Paused"):
+        vault_proxy.earn({"from": governance})
+    with brownie.reverts("Pausable: GAC Paused"):
+        vault_proxy.withdraw(123, {"from": user})
+    with brownie.reverts("Pausable: GAC Paused"):
+        vault_proxy.withdrawAll({"from": user})
+    with brownie.reverts("Pausable: GAC Paused"):
+        vault_proxy.deposit(123, {"from": user})
+    with brownie.reverts("Pausable: GAC Paused"):
+        vault_proxy.depositAll({"from": user})
+    with brownie.reverts("Pausable: GAC Paused"):
+        vault_proxy.transfer(accounts[1], 123, {"from": user})
+    with brownie.reverts("Pausable: GAC Paused"):
+        vault_proxy.transferFrom(user, accounts[1], 123, {"from": accounts[1]})
+
+    # Unpausing globally
+    gac.unpause({"from": gac_gov})
+    assert gac.paused() == False
+
+    # Testing all operations
+
+    ## Withdraw
+    underlying = ERC20Upgradeable.at(vault_proxy.token())
+    prev_balance_of_underlying = underlying.balanceOf(user)
+    vault_proxy.withdraw(1000, {"from": user})
+    assert underlying.balanceOf(user) > prev_balance_of_underlying
+
+    ## Deposit
+    prev_shares = vault_proxy.balanceOf(user)
+    prev_balance_of_underlying = underlying.balanceOf(user)
+    underlying.approve(vault_proxy, underlying.balanceOf(user), {"from": user})
+    vault_proxy.deposit(underlying.balanceOf(user) / 2, {"from": user})
+    assert underlying.balanceOf(user) < prev_balance_of_underlying
+    assert vault_proxy.balanceOf(user) > prev_shares
+
+    ## DepositAll
+    prev_shares = vault_proxy.balanceOf(user)
+    prev_balance_of_underlying = underlying.balanceOf(user)
+    vault_proxy.depositAll({"from": user})
+    assert underlying.balanceOf(user) < prev_balance_of_underlying
+    assert vault_proxy.balanceOf(user) > prev_shares
+
+    # Earn
+    prev_balance = vault_proxy.balance()
+    vault_proxy.earn({"from": governance})
+    assert vault_proxy.balance() == prev_balance
+
+    ## Transfer From
+    rando = accounts[1]
+    amount = vault_proxy.balanceOf(user) / 4
+    vault_proxy.approve(rando, vault_proxy.balanceOf(user), {"from": user})
+    vault_proxy.transferFrom(user.address, rando.address, amount, {"from": rando})
+    assert vault_proxy.balanceOf(rando.address) == amount
+
+    # Transfer
+    vault_proxy.transfer(accounts[2], amount, {"from": rando})
+    assert vault_proxy.balanceOf(accounts[2]) == amount
+
+
+@pytest.mark.parametrize(
+    "settAddress",
+    SETT_ADDRESSES_V1 + SETT_ADDRESSES_V1_1 + SETT_ADDRESSES_V4,
+)
+def test_gac_blacklist(settAddress, proxy_admin, proxy_admin_gov, bve_cvx, bcvx_crv):
+    # UPGRADE block
+    if settAddress in SETT_ADDRESSES_V1:
+        vault_proxy = SettV1h.at(settAddress)
+        governance = accounts.at(vault_proxy.governance(), force=True)
+
+        new_vault_logic = SettV1h.deploy({"from": governance})
+
+    elif settAddress in SETT_ADDRESSES_V1_1:
+        vault_proxy = SettV1_1h.at(settAddress)
+        governance = accounts.at(vault_proxy.governance(), force=True)
+
+        new_vault_logic = SettV1_1h.deploy({"from": governance})
+    else:
+        vault_proxy = SettV4h.at(settAddress)
+        governance = accounts.at(vault_proxy.governance(), force=True)
+
+        new_vault_logic = SettV4h.deploy({"from": governance})
+
+    if bve_cvx.paused() and not settAddress == bve_cvx.address:
+        bve_gov = accounts.at(bve_cvx.governance(), force=True)
+        bve_cvx.unpause({"from": bve_gov})
+
+    if bcvx_crv.paused() and not settAddress == bcvx_crv.address:
+        bcvx_crv_gov = accounts.at(bcvx_crv.governance(), force=True)
+        bcvx_crv.unpause({"from": bcvx_crv_gov})
+
+    # Execute upgrade
+    proxy_admin.upgrade(vault_proxy, new_vault_logic, {"from": proxy_admin_gov})
+
+    ## You can unpause if GAC is paused or unpaused (SettV1 can't be paused directly)
+    try:
+        if vault_proxy.paused() == True:
+            vault_proxy.unpause({"from": governance})
+            assert vault_proxy.paused() == False
+    except:
+        pass
+
+    ## GAC Pause Block
+
+    ## Get GAC actors
+    gac = interface.IGac(vault_proxy.GAC())
+    gac_gov = accounts.at(gac.DEV_MULTISIG(), force=True)
+
+    # Unpausing globally
+    if gac.paused():
+        gac.unpause({"from": gac_gov})
+
+    # Focused on testing pausing functionality
+    if gac.transferFromDisabled():
+        gac.enableTransferFrom({"from": gac_gov})
+
+    ## GAC Blacklist Block
+
+    # Define actors
+    user = accounts[0]
+    rando = accounts[1]
+    want = interface.ERC20(vault_proxy.token())
+
+    for exploiter in LIST_OF_EXPLOITERS:
+        # Blacklist exploiters
+        blacklisted_role = gac.BLACKLISTED_ROLE()
+        gac.grantRole(blacklisted_role, exploiter, {"from": gac_gov})
+
+        want_balance = want.balanceOf(exploiter)
+        vault_balance = vault_proxy.balanceOf(exploiter)
+
+        ## Should revert for exploiters
+        with brownie.reverts("blacklisted"):
+            vault_proxy.deposit(want_balance, {"from": exploiter})
+
+        if settAddress in SETT_ADDRESSES_V4:
+            with brownie.reverts("blacklisted"):
+                vault_proxy.deposit(want_balance, [], {"from": exploiter})
+
+        with brownie.reverts("blacklisted"):
+            vault_proxy.depositAll({"from": exploiter})
+
+        if settAddress in SETT_ADDRESSES_V4:
+            with brownie.reverts("blacklisted"):
+                vault_proxy.depositAll([], {"from": exploiter})
+
+        if settAddress in [SETT_ADDRESSES_V1, SETT_ADDRESSES_V4]:
+            with brownie.reverts("blacklisted"):
+                vault_proxy.depositFor(rando, want_balance, {"from": exploiter})
+
+        with brownie.reverts("blacklisted"):
+            vault_proxy.withdraw(vault_balance, {"from": exploiter})
+
+        with brownie.reverts("blacklisted"):
+            vault_proxy.withdrawAll({"from": exploiter})
+
+        with brownie.reverts("blacklisted"):
+            vault_proxy.transfer(rando, vault_balance, {"from": exploiter})
+
+        with brownie.reverts("blacklisted"):
+            vault_proxy.transferFrom(
+                user, rando, vault_proxy.balanceOf(user), {"from": exploiter}
+            )
+
+        vault_proxy.approve(rando, MAX_UINT256, {"from": exploiter})
+        with brownie.reverts("blacklisted"):
+            vault_proxy.transferFrom(exploiter, rando, vault_balance, {"from": rando})
+
+    ## No reverts for user
+    want_balance = want.balanceOf(user)
+    vault_balance = vault_proxy.balanceOf(user)
+
+    vault_proxy.deposit(want_balance, {"from": user})
+
+    if settAddress in SETT_ADDRESSES_V4:
+        vault_proxy.deposit(want_balance, [], {"from": user})
+
+    vault_proxy.depositAll({"from": user})
+
+    if settAddress in SETT_ADDRESSES_V4:
+        vault_proxy.depositAll([], {"from": user})
+
+    if settAddress in [SETT_ADDRESSES_V1, SETT_ADDRESSES_V4]:
+        vault_proxy.depositFor(rando, want_balance, {"from": user})
+
+    vault_proxy.withdraw(vault_balance, {"from": user})
+
+    vault_proxy.withdrawAll({"from": user})
+
+    vault_proxy.transfer(rando, vault_balance, {"from": user})
+
+    vault_proxy.transferFrom(
+        user, rando, vault_proxy.balanceOf(user), {"from": user}
+    )
+
+    vault_proxy.approve(rando, MAX_UINT256, {"from": user})
+    vault_proxy.transferFrom(user, rando, vault_balance, {"from": rando})

--- a/tests/test_paused_gac.py
+++ b/tests/test_paused_gac.py
@@ -1,3 +1,0 @@
-"""
-TODO: Verify that GAC pausing pauses the Setts
-"""


### PR DESCRIPTION
- Add `whenNotPaused` to other `SettV1_1h` functions to make it consistent with `SettV4`
- Check if `msg.sender` or `sender` is blacklisted in GAC

Still need to think the blacklist through. With the blacklist, we're trying to solve two things:
1. Attacker shouldn't be able to call `transferFrom` to exploit malicious approvals
2. Attacker shouldn't be able to deposit/withdraw/move their tokens